### PR TITLE
Get insight as to why same file alias method isn't working

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -102,9 +102,17 @@ module.exports = class AliasRepository extends Array {
     }
 
     getAliasGroupsFromSameFileAs(aliasMember) {
+        console.log('========================================');
+        console.log(`getAliasGroupsFromSameFileAs(${aliasMember})`)
         aliasMember = aliasMember.toLowerCase();
+        console.log(`  aliasMember = ${aliasMember}`);
         var ag = this.getAliasGroup(aliasMember);
-        return this.filter(otherAliasGroup => otherAliasGroup.sourcefile === ag.sourcefile);
+        console.log(ag);
+        var result = this.filter(otherAliasGroup => otherAliasGroup.sourcefile === ag.sourcefile);
+        console.log(this[0]);
+        console.log(result);
+        console.log();
+        return result;
     }
 
     


### PR DESCRIPTION
I'm trying to see why this function is breaking down. I know it's happening here due to the error that's happening for lcc and chincome.