### PR TITLE
`cyberquincy` isn't in the directory structure in remote, duh. Just look for `./aliases` instead!!

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -13,7 +13,7 @@ module.exports = class AliasRepository extends Array {
                 var tokens = fpath.split();
 
                 var relPath = './' + tokens.slice(
-                    tokens.findIndex(i => i === 'cyberquincy') + 1
+                    tokens.findIndex(i => i === 'aliases')
                 ).join('/');
 
                 this.loadAliasFile(relPath);


### PR DESCRIPTION
This should fix it 🤞 