### PR TITLE
Abstract Parser Generalization (and the addition of the OrParser and EmptyParser)

### DIFF
--- a/1/config.json
+++ b/1/config.json
@@ -1,15 +1,15 @@
 {
     "prefix": "q!",
-    "token": "mo",
+    "token": "NzM3MDk0MDI3NDAwMTgzODY4.Xx4WTg.fzZ0fJIKNXkjEsrYOkXSZZYp_6I",
     "colour": "#00E6BB",
-    "type": "no",
-    "project_id": "no",
-    "private_key_id": "no",
-    "private_key": "no",
-    "client_email": "no",
-    "client_id": "no",
-    "auth_uri": "no",
-    "token_uri": "no",
-    "auth_provider_x509_cert_url": "no",
-    "client_x509_cert_url": "no"
+    "type": "service_account",
+    "project_id": "cyber-quincy-285110",
+    "private_key_id": "341e25a5e300976173526793958b864cfe71b11d",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDSyG54GMw+XW0b\nxrpOofzR1ffdsmZTGZakH6Ab7aHL9qQpQ7vEjhD7G+olxC60159vj5mAzjtirkud\ngKMdi/rLACpDTfAc2+fzYJi73yT4m6WzS3E26roJE4KtUzoaL+oFFnKcyY8GS33x\n2APZpNxEy87eGZMRWiVkqafQdJtONW/xfjJrpfNL04WuUZyvpxx8WhZPI3YzDxsj\nqyGegpANBw6DZjYqOW2t0qa9mnX+KBVC5e20RguBo9geSzEunKD85Cdayd2mCBrG\nHPBWrTHfc9emhGiB6RnnI6noxi+DbLuoFEhDbJRTteuaA4E20m5blpaOnhTC1Hcy\nwFgBt7wDAgMBAAECggEAEdtzKG+JYvTNTCyFsI9R303n5hTs5rgxplpOv5VeC+z4\nTJqonk1SEpDZ2s5up1mBI2I6C5e6Bj3+UyvVWQ9FdWWtLu7vNOXlSVDzGS+D1VM/\nMk8ygNS//NbcG+adWVMBc3uxK0FHaBQeaZr2yiO7/+p4VLtvImnNszDmvublS9Ap\nrX+Zv6v6wD9ctj6lcwOR7VKP4Pp6itNbuZoNwGuQNQhTbNV4oAAyaLu3pTnJ4nqA\nFFVMJcLrT7sXhc5VdwJwri0slw1ohVYwhHXy8hXgCYyGHW/NdKrTvNKEWHm8luwx\noYucDZVybFysZnJf9omrORytP61G+bOBJSfN1+HzMQKBgQD6fzLlO5kEA6ixk77b\nv3aX2844C2eoQTpeGfVUWgDy0IFxqeCvAqxHu+IweFhODw1RAhsr5K4vnXHOq9XY\nUw35Wsgshx0yy0oJNdCZlin04DxYmYbW9s9kFse030G9A92Rmcz2vAKf+TAbCTlo\nX+RNUBjpeo31IONg4p30y8rhOwKBgQDXaeFmGd3inDd5IfiL1nEnn5Lw7C1AeyBW\n0ZRWwf9SRkNTTOEFisGJFuJhsyjWcvlEPzdYuBysgjdT3rB4+EJXmTU9PUesi2d5\nvyQFmcDg+UoCoDwwHT/QQlN5jS3c6ZbwsPH5ERZZ9zYPIN5PbRMGwUx9c3ti7r6Y\n0FzTHp9j2QKBgFfYmbmoL94nhlZYENuxhl51GBmxbjWkQlrT0aQ2OBTvKCX7RC87\nyb0SV51V5ung/3OEQJEhDjDmjw3CVykY31KuEnsDGys//YPDWpcyAR6+MIuFs7LZ\nNRvNnVWB4eTuYRp5jFaO0oDVe5hPoNFIp6CxUTs33mazlOnaLzi06z4XAoGBAJX6\nXPlWVxsYgrLuyPqrchsRSiA9f4AeebSYtHv3E8n3q5ZKt3zBT+Afs7wsHem5IP24\nOdOmVChzfQwCxsFir+YHgH7DtKxYXtHwF6dillzMlA/h+iXRp4VbOH0vo1fktreb\nqs0rbXFz4gqEauPH4HBakuPhTG3kJYWFxKsk7fp5AoGANLHw/1y84qAiqO6TrESr\nvN69h0Q60jy5RZP5sBYHIb+CWhjv2C9/0CZRhtm6c/DuIrePuq1UuxuDuzKnAFR7\nGy7ymln4+tZ3ZIDjQLpdeoXK5tLuEz8i/cfjxZ3Jo4qlUVUOILfCtFemsFuFfh5G\nQfll7PT3pGrk3OgcT4mrnmE=\n-----END PRIVATE KEY-----\n",
+    "client_email": "cyber-quincy-12@cyber-quincy-285110.iam.gserviceaccount.com",
+    "client_id": "115293497820643289399",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/cyber-quincy-12%40cyber-quincy-285110.iam.gserviceaccount.com"
 }

--- a/1/config.json
+++ b/1/config.json
@@ -1,15 +1,15 @@
 {
     "prefix": "q!",
-    "token": "NzM3MDk0MDI3NDAwMTgzODY4.Xx4WTg.fzZ0fJIKNXkjEsrYOkXSZZYp_6I",
+    "token": "mo",
     "colour": "#00E6BB",
-    "type": "service_account",
-    "project_id": "cyber-quincy-285110",
-    "private_key_id": "341e25a5e300976173526793958b864cfe71b11d",
-    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDSyG54GMw+XW0b\nxrpOofzR1ffdsmZTGZakH6Ab7aHL9qQpQ7vEjhD7G+olxC60159vj5mAzjtirkud\ngKMdi/rLACpDTfAc2+fzYJi73yT4m6WzS3E26roJE4KtUzoaL+oFFnKcyY8GS33x\n2APZpNxEy87eGZMRWiVkqafQdJtONW/xfjJrpfNL04WuUZyvpxx8WhZPI3YzDxsj\nqyGegpANBw6DZjYqOW2t0qa9mnX+KBVC5e20RguBo9geSzEunKD85Cdayd2mCBrG\nHPBWrTHfc9emhGiB6RnnI6noxi+DbLuoFEhDbJRTteuaA4E20m5blpaOnhTC1Hcy\nwFgBt7wDAgMBAAECggEAEdtzKG+JYvTNTCyFsI9R303n5hTs5rgxplpOv5VeC+z4\nTJqonk1SEpDZ2s5up1mBI2I6C5e6Bj3+UyvVWQ9FdWWtLu7vNOXlSVDzGS+D1VM/\nMk8ygNS//NbcG+adWVMBc3uxK0FHaBQeaZr2yiO7/+p4VLtvImnNszDmvublS9Ap\nrX+Zv6v6wD9ctj6lcwOR7VKP4Pp6itNbuZoNwGuQNQhTbNV4oAAyaLu3pTnJ4nqA\nFFVMJcLrT7sXhc5VdwJwri0slw1ohVYwhHXy8hXgCYyGHW/NdKrTvNKEWHm8luwx\noYucDZVybFysZnJf9omrORytP61G+bOBJSfN1+HzMQKBgQD6fzLlO5kEA6ixk77b\nv3aX2844C2eoQTpeGfVUWgDy0IFxqeCvAqxHu+IweFhODw1RAhsr5K4vnXHOq9XY\nUw35Wsgshx0yy0oJNdCZlin04DxYmYbW9s9kFse030G9A92Rmcz2vAKf+TAbCTlo\nX+RNUBjpeo31IONg4p30y8rhOwKBgQDXaeFmGd3inDd5IfiL1nEnn5Lw7C1AeyBW\n0ZRWwf9SRkNTTOEFisGJFuJhsyjWcvlEPzdYuBysgjdT3rB4+EJXmTU9PUesi2d5\nvyQFmcDg+UoCoDwwHT/QQlN5jS3c6ZbwsPH5ERZZ9zYPIN5PbRMGwUx9c3ti7r6Y\n0FzTHp9j2QKBgFfYmbmoL94nhlZYENuxhl51GBmxbjWkQlrT0aQ2OBTvKCX7RC87\nyb0SV51V5ung/3OEQJEhDjDmjw3CVykY31KuEnsDGys//YPDWpcyAR6+MIuFs7LZ\nNRvNnVWB4eTuYRp5jFaO0oDVe5hPoNFIp6CxUTs33mazlOnaLzi06z4XAoGBAJX6\nXPlWVxsYgrLuyPqrchsRSiA9f4AeebSYtHv3E8n3q5ZKt3zBT+Afs7wsHem5IP24\nOdOmVChzfQwCxsFir+YHgH7DtKxYXtHwF6dillzMlA/h+iXRp4VbOH0vo1fktreb\nqs0rbXFz4gqEauPH4HBakuPhTG3kJYWFxKsk7fp5AoGANLHw/1y84qAiqO6TrESr\nvN69h0Q60jy5RZP5sBYHIb+CWhjv2C9/0CZRhtm6c/DuIrePuq1UuxuDuzKnAFR7\nGy7ymln4+tZ3ZIDjQLpdeoXK5tLuEz8i/cfjxZ3Jo4qlUVUOILfCtFemsFuFfh5G\nQfll7PT3pGrk3OgcT4mrnmE=\n-----END PRIVATE KEY-----\n",
-    "client_email": "cyber-quincy-12@cyber-quincy-285110.iam.gserviceaccount.com",
-    "client_id": "115293497820643289399",
-    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "token_uri": "https://oauth2.googleapis.com/token",
-    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/cyber-quincy-12%40cyber-quincy-285110.iam.gserviceaccount.com"
+    "type": "no",
+    "project_id": "no",
+    "private_key_id": "no",
+    "private_key": "no",
+    "client_email": "no",
+    "client_id": "no",
+    "auth_uri": "no",
+    "token_uri": "no",
+    "auth_provider_x509_cert_url": "no",
+    "client_x509_cert_url": "no"
 }

--- a/parser/command-parser.js
+++ b/parser/command-parser.js
@@ -143,8 +143,6 @@ function permutateOptionalParser(parsers) {
     ]
 }
 
-// Just deals with one OrParser at a time for simplicity
-// Recursion/iteration will catch the rest
 function expandOrParser(parsers) {
     orParserIndex = parsers.findIndex(p => p instanceof OrParser)
 
@@ -179,6 +177,7 @@ function removeEmptyParser(parsers) {
     moreConcreteParsers = parsers.slice(0, emptyParserIndex)
                                 .concat(parsers.slice(emptyParserIndex + 1));
 
+    // No values were parsed in the OrParser concretization process
     return {parsers: moreConcreteParsers, parsed: new Parsed()}
 }
 
@@ -201,8 +200,8 @@ function parseConcrete(args, parsers) {
         parser = parsers[i];
         arg = args[i];
 
-        if (parser instanceof OptionalParser) {
-            throw 'Optional parser found in concrete parsing. Something went wrong here.';
+        if (isAbstract(parser)) {
+            throw `Abstract parser of type ${typeof Parser} found in concrete parsing. Something went wrong here.`;
         }
 
         try {

--- a/parser/empty-parser.js
+++ b/parser/empty-parser.js
@@ -1,0 +1,12 @@
+const DeveloperCommandError = require("../exceptions/developer-command-error");
+
+// parses nothing
+module.exports = class EmptyParser {
+    type() {
+        return 'empty';
+    }
+
+    parse(_) {
+        throw new DeveloperCommandError(`EmptyParser is a placeholder not meant to be parsed`);
+    }
+}

--- a/parser/optional-parser.js
+++ b/parser/optional-parser.js
@@ -17,7 +17,7 @@ module.exports = class OptionalParser {
     // The optional parser type is the type of the concrete parser wrapped in parentheses
     // This notation indicates that the corresponding argument is optional
     type() {
-        return '(' + this.parser.type() + ')';
+        return 'optional';
     }
 
     parse(arg) {

--- a/parser/or-parser.js
+++ b/parser/or-parser.js
@@ -1,0 +1,41 @@
+// A wrapper around any number of lists of parsers
+
+const DeveloperCommandError = require("../exceptions/developer-command-error");
+
+// to allow various ways to use parse arguments and ultimately use a command
+module.exports = class OrParser {
+    // Takes in the concrete parser and a default value is the parser fails to parse
+    constructor(...parserLists) {
+        this.parserLists = parserLists;
+
+        if (!(this.parserLists instanceof Array)) {
+            throw new DeveloperCommandError(
+                `OrParser expects a list of parser lists but got ${typeof this.parserLists} instead`
+            );
+        }
+
+        if (this.parserLists.length < 2) {
+            throw new DeveloperCommandError(
+                `OrParser must take at least 2 arguments but got just ${this.parserLists.length} instead`
+            );
+        }
+
+        for (var i = 0; i < parserLists.length; i++) {
+            parsers = parserLists[i];
+            if (!(parsers instanceof Array)) {
+                throw new DeveloperCommandError(
+                    `OrParser arguments must be Arrays of Parsers but ` +
+                     `${toOrdinalSuffix(i)} argument was type ${typeof parsers}.`
+                );
+            }
+        }
+    }
+
+    type() {
+        return 'or';
+    }
+
+    parse(_) {
+        throw `Must not parse directly from the OrParser. Must parse argument list parsers instead`
+    }
+}

--- a/parser/or-parser.js
+++ b/parser/or-parser.js
@@ -1,5 +1,3 @@
-// A wrapper around any number of lists of parsers
-
 const DeveloperCommandError = require("../exceptions/developer-command-error");
 
 // to allow various ways to use parse arguments and ultimately use a command

--- a/parser/string-set-values-parser.js
+++ b/parser/string-set-values-parser.js
@@ -49,7 +49,7 @@ module.exports = class StringSetValuesParser {
                             .map((v) => `\`${v}\``)
                             .join(', ');
                 } else {
-                    erorrValues = this.values.join(', ');
+                    errorValues = this.values.join(', ')
                 }
                 throw new UserCommandError(
                     `"${arg}" is not one of available values: ${errorValues}`


### PR DESCRIPTION
This'll come in use for my plans for 2MP and potential ways to improve existing BTD6-Index commands. Will ultimately just be really fundamental to the command/parsing infrastructure and the code is much cleaner now.

What this accomplishes is that it solidifies the idea of an "abstract parser", basically a parser that wraps zero or more concrete parsers but don't parse arguments themselves. Our currently library is

* `EmptyParser`: parses nothing. Good if you want to use an `OptionalParser` but without a default value, in which case you would use `new OrParser(new ConcreteParser(), new EmptyParser())`
* `OrParser`: takes in N>=2 parser lists. The `commandParser` runs `N` parsing attempts by by replacing the `OrParser` with each of the `N` parsing lists.
* `OptionalParser`: not new, see README.

Look at `ABSTRACT_PARSERS` plus the above comment where it's declared to learn how to create one if necessary.