### PR TITLE
Better parsing error messages / easier to write most common parsers

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -22,7 +22,7 @@ module.exports = class AliasRepository extends Array {
                 var relPath =
                     './' +
                     tokens
-                        .slice(tokens.findIndex((i) => i === 'aliases'))
+                        .slice(tokens.findIndex(i => i === 'aliases'))
                         .join('/');
 
                 // Determine the function that will handle the alias file
@@ -104,14 +104,14 @@ module.exports = class AliasRepository extends Array {
             var nextAliasSet = nextAliasGroup.aliases.concat(nextAliasGroup.canonical);
             var existingAliasSet = existingAliasGroup.aliases.concat(existingAliasGroup.canonical);
 
-            var sharedAliasMembers = nextAliasSet.filter((aliasMember) =>
+            var sharedAliasMembers = nextAliasSet.filter(aliasMember =>
                 existingAliasSet.includes(aliasMember)
             );
 
             if (sharedAliasMembers.length > 0) {
                 throw new AliasError(
                     `Aliases members [${sharedAliasMembers.map(
-                        (a) => `"${a}"`
+                        a => `"${a}"`
                     )}] clash among existing group ` +
                         `${this.formatAliasGroup(
                             existingAliasGroup
@@ -141,7 +141,7 @@ module.exports = class AliasRepository extends Array {
     // in which aliasMember is found
     getAliasGroup(aliasMember) {
         var ags = this.filter(
-            (ag) =>
+            ag =>
                 ag.canonical == aliasMember || ag.aliases.includes(aliasMember)
         );
         if (!ags || ags.length == 0) {
@@ -152,7 +152,7 @@ module.exports = class AliasRepository extends Array {
             throw (
                 `Multiple alises groups found sharing a given alias member` +
                 `(something went horribly wrong): ${ags.map(
-                    (ag) => ag.canonical
+                    ag => ag.canonical
                 )}`
             );
         }
@@ -170,7 +170,7 @@ module.exports = class AliasRepository extends Array {
         aliasMember = aliasMember.toLowerCase();
         var ag = this.getAliasGroup(aliasMember);
         var result = this.filter(
-            (otherAliasGroup) => otherAliasGroup.sourcefile === ag.sourcefile
+            otherAliasGroup => otherAliasGroup.sourcefile === ag.sourcefile
         );
         return result;
     }
@@ -189,13 +189,25 @@ module.exports = class AliasRepository extends Array {
             .concat(hardMaps)
             .concat(expertMaps);
 
-        return allMaps.map((ag) => ag.canonical);
+        return allMaps.map(ag => ag.canonical);
+    }
+
+    allMapDifficulties() {
+        const map_difficulties = this.getAliasGroupsFromSameFileAs('INTERMEDIATE');
+
+        return map_difficulties.map(ag => ag.canonical);
+    }
+
+    allDifficulties() {
+        const difficulties = this.getAliasGroupsFromSameFileAs('MEDIUM');
+
+        return difficulties.map(ag => ag.canonical).concat("IMPOPPABLE");
     }
 
     allModes() {
         const modes = this.getAliasGroupsFromSameFileAs('STANDARD');
 
-        return modes.map((ag) => ag.canonical);
+        return modes.map(ag => ag.canonical);
     }
 
     TOWER_CANONICAL_REGEX = /[a-z]#\d\d\d/i;

--- a/alias-repository.js
+++ b/alias-repository.js
@@ -201,7 +201,7 @@ module.exports = class AliasRepository extends Array {
     allDifficulties() {
         const difficulties = this.getAliasGroupsFromSameFileAs('MEDIUM');
 
-        return difficulties.map(ag => ag.canonical).concat("IMPOPPABLE");
+        return difficulties.map(ag => ag.canonical).concat("impoppable");
     }
 
     allModes() {

--- a/aliases/map-difficulties.json
+++ b/aliases/map-difficulties.json
@@ -1,0 +1,6 @@
+{
+    "beginner": ["beg"],
+    "intermediate": ["int"],
+    "advanced": ["adv"],
+    "expert": ["exp", "expr", "exprt"]
+}

--- a/aliases/maps/beginner-maps.json
+++ b/aliases/maps/beginner-maps.json
@@ -28,6 +28,7 @@
         "endroad",
         "end_road",
         "end",
-        "road"
+        "road",
+        "eotr"
     ]
 }

--- a/commands/index-2tc.js
+++ b/commands/index-2tc.js
@@ -75,7 +75,7 @@ module.exports = {
             } else { // and map NOT specified
                 towers = null;
                 try { towers = normalizeTowers(parsed.tower_upgrades, parsed.heroes); }
-                catch(e) { err(e, message); }
+                catch(e) { return err(e, message); }
 
                 if (towers.length == 1) { // 1 tower provided
                     return message.channel.send(`Multiple-combo searching coming soon`);

--- a/commands/index-lcc.js
+++ b/commands/index-lcc.js
@@ -31,7 +31,7 @@ module.exports = {
         if (parsed.hasErrors()) {
             return module.exports.errorMessage(message, parsed.parsingErrors);
         }
-        
+
         var btd6_map = parsed.map;
 
         async function displayLCC(btd6_map) {
@@ -51,11 +51,15 @@ module.exports = {
                 // input is "in_the_loop" but needs to be compared to "In The Loop"
                 if (
                     mapCandidate &&
-                    mapCandidate.toLowerCase().replace(' ', '_') === btd6_map
+                    mapCandidate.toLowerCase().replace(/ /g, '_') === btd6_map
                 ) {
                     entryRow = row;
                     break;
                 }
+            }
+
+            if (!entryRow) {
+                throw `Something has gone horribly wrong; ${btd6_map} passed parsing validation but can't be found in the LCC spreadsheet`;
             }
 
             // Load the row where the map was found

--- a/commands/index-ltc.js
+++ b/commands/index-ltc.js
@@ -92,7 +92,7 @@ module.exports = {
                 // input is "in_the_loop" but needs to be compared to "In The Loop"
                 if (
                     mapCandidate &&
-                    mapCandidate.toLowerCase().replace(' ', '_') === btd6_map
+                    mapCandidate.toLowerCase().replace(/ /g, '_') === btd6_map
                 ) {
                     entryRow = row;
                     break;

--- a/helpers/general.js
+++ b/helpers/general.js
@@ -3,6 +3,10 @@ module.exports = {
         return typeof s === 'string' || s instanceof String;
     },
 
+    is_fn(f) {
+        return f && {}.toString.call(f) === '[object Function]';
+    },
+
     numberWithCommas(x) {
         return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
     },

--- a/helpers/general.js
+++ b/helpers/general.js
@@ -41,6 +41,17 @@ module.exports = {
         return result;
     },
 
+    shuffle(inputArr) {
+        arr = [...inputArr];
+        for(let i = arr.length - 1; i > 0; i--){
+            const j = Math.floor(Math.random() * i)
+            const temp = arr[i]
+            arr[i] = arr[j]
+            arr[j] = temp
+        }
+        return arr;
+    },
+
     range(start, end) {
         return Array(end - start + 1)
             .fill()

--- a/parser/difficulty-parser.js
+++ b/parser/difficulty-parser.js
@@ -1,32 +1,15 @@
-StringSetValuesParser = require('./string-set-values-parser.js');
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
 
-module.exports = class DifficultyParser {
-    VALID_DIFFICULTIES = ['IMPOPPABLE', 'HARD', 'MEDIUM', 'EASY'];
-
+module.exports = class MapParser {
     type() {
         return 'difficulty';
     }
 
     constructor(...permitted_difficulties) {
-        // permitted difficulties must be a subset of valid difficulties
-        // i.e. if command developer tried to put "cheese" it would error for obvious reasons
-        for (let i = 0; i < permitted_difficulties.length; i++) {
-            if (!this.VALID_DIFFICULTIES.includes(permitted_difficulties[i])) {
-                throw new DeveloperCommandError(
-                    `${permitted_difficulties[i]} is not a valid difficulty`
-                );
-            }
-        }
-
-        // If no permitted difficulties are provided, the permitted difficulties defaults to ALL difficulties
-        if (permitted_difficulties.length === 0) {
-            permitted_difficulties = this.VALID_DIFFICULTIES;
-        }
-
-        // DifficultyParser is just a specific instance of StringSetValuesParser with some additional validation
-        // Decided to run with composition over inheritance because inheritance constructor rules are disgusting.
-        this.delegateParser = new StringSetValuesParser(
-            ...permitted_difficulties.map((d) => d.toLowerCase())
+        this.delegateParser = new LimitedStringSetValuesParser(
+            this.type(),
+            Aliases.allDifficulties(),
+            permitted_difficulties.map(d => d.toLowerCase()),
         );
     }
 

--- a/parser/hero-parser.js
+++ b/parser/hero-parser.js
@@ -1,4 +1,4 @@
-StringSetValuesParser = require('./string-set-values-parser.js');
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
 
 module.exports = class HeroParser {
     type() {
@@ -6,23 +6,10 @@ module.exports = class HeroParser {
     }
 
     constructor(...permitted_heroes) {
-        // permitted heroes must be a subset of valid heroes
-        // i.e. if command developer tried to put "cheese" it would error for obvious reasons
-        for (let i = 0; i < permitted_heroes.length; i++) {
-            if (!Aliases.allheroes().includes(permitted_heroes[i])) {
-                throw new DeveloperCommandError(
-                    `${permitted_heroes[i]} is not a valid hero`
-                );
-            }
-        }
-
-        // If no permitted heroes are provided, the permitted heroes defaults to ALL heroes
-        if (permitted_heroes.length === 0) {
-            permitted_heroes = Aliases.allHeroes();
-        }
-
-        this.delegateParser = new StringSetValuesParser(
-            ...permitted_heroes.map((d) => d.toLowerCase())
+        this.delegateParser = new LimitedStringSetValuesParser(
+            this.type(),
+            Aliases.allHeroes(),
+            permitted_heroes.map(d => d.toLowerCase()),
         );
     }
 

--- a/parser/limited-string-set-values-parser.js
+++ b/parser/limited-string-set-values-parser.js
@@ -1,3 +1,5 @@
+pluralize = require('pluralize');
+
 const DeveloperCommandError = require('../exceptions/developer-command-error.js');
 const UserCommandError = require('../exceptions/user-command-error.js');
 
@@ -56,18 +58,23 @@ module.exports = class LimitedStringSetValuesParser {
     }
 
     errorMessage(badValue) {
+        const NUM_EXAMPLE_VALUES = 5;
+
         const acceptedValues = h.shuffle(this.permittedValues);
 
-        const exampleValues = acceptedValues.slice(0, Math.min(acceptedValues.length, 3))
+        const exampleValues = acceptedValues.slice(0, Math.min(acceptedValues.length, NUM_EXAMPLE_VALUES))
                                       .map(v => {
                                           let aliases = Aliases.getAliasSet(v) || [v];
                                           return aliases[Math.floor(Math.random() * aliases.length)];
                                       });
 
+        const etc = acceptedValues.length > NUM_EXAMPLE_VALUES ? ', etc. ' : '';
+
         let msg = ''
-        msg += `${badValue} is neither an accepted ${this.supertype} nor a ${this.supertype} alias for this command. `
-        msg += `Valid examples include ${exampleValues.map(v => `\`${v}\``).join(', ')}, etc. `;
-        msg += `Use \`q!alias <proper_${this.supertype}_name>\` to learn ${this.supertype}-name shorthands.`
+        msg += `\`${badValue}\` is neither an accepted ${this.supertype} nor a ${this.supertype} alias for this command. `
+        msg += `Valid examples include ${exampleValues.map(v => `\`${v}\``).join(', ')}${etc}. `;
+        msg += `Use \`q!alias <proper_${this.supertype}_name>\` (i.e. \`q!alias ${exampleValues[0]}\`) `
+        msg += `to learn shorthands for various ${pluralize(this.supertype)}.`
         return msg;
     }
 };

--- a/parser/limited-string-set-values-parser.js
+++ b/parser/limited-string-set-values-parser.js
@@ -1,0 +1,59 @@
+const DeveloperCommandError = require('../exceptions/developer-command-error.js');
+const UserCommandError = require('../exceptions/user-command-error.js');
+
+StringSetValuesParser = require('./string-set-values-parser.js');
+
+module.exports = class LimitedStringSetValuesParser {
+    type() {
+        return 'limited_string_set_value';
+    }
+
+    constructor(possible_values, type, permitted_values=null, errorMessage=null) {
+        if (!(possible_values instanceof Array)) {
+            throw new DeveloperCommandError(`Possible values "${possible_values}" (first arg) must be an array`);
+        }
+
+        if (!(h.is_str(type))) {
+            throw new DeveloperCommandError(`Type "${type}" (second arg) must be an string`);
+        }
+
+        if (permitted_values && !(permitted_values instanceof Array)) {
+            throw new DeveloperCommandError(`Permitted values "${permitted_values}" (third arg) must be null or an array`);
+        }
+
+        if (!(h.is_fn(errorMessage))) {
+            throw new DeveloperCommandError(`Error Message "${errorMessage}" (fourth arg) must be null or a function expecting one argument: a string that didn't match the ${type} parser`);
+        }
+
+        // Ensure that the permitted values provided by the developer are a subset of all possible values
+        if (permitted_values && permitted_values.length > 0) {
+            for (let i = 0; i < permitted_values.length; i++) {
+                if (possible_values && !possible_values.includes(permitted_values[i])) {
+                    throw new DeveloperCommandError(
+                        `${permitted_values[i]} is not a valid ${type}`
+                    );
+                }
+            }
+        } else {
+            // Permitted values are set to all possible values if not provided
+            permitted_values = [...possible_values];
+        }
+
+        this.delegateParser = new StringSetValuesParser(
+            ...permitted_values
+        );
+
+        this.errorMessage = errorMessage;
+    }
+
+    parse(arg) {
+        // Delegate the parsing work to the StringSetValuesParser
+        try {
+            return this.delegateParser.parse(arg);
+        } catch(e) {
+            if (e instanceof UserCommandError && this.errorMessage) {
+                throw new UserCommandError(this.errorMessage(arg))
+            } else throw e;
+        }
+    }
+};

--- a/parser/map-difficulty-parser.js
+++ b/parser/map-difficulty-parser.js
@@ -1,31 +1,15 @@
-StringSetValuesParser = require('./string-set-values-parser.js');
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
 
 module.exports = class MapDifficultyParser {
-    VALID_DIFFICULTIES = ["BEGINNER", "INTERMEDIATE", "ADVANCED", "EXPERT"];
-
     type() {
         return 'map_difficulty';
     }
 
     constructor(...permitted_map_difficulties) {
-        // permitted map difficulties must be a subset of valid map difficulties
-        // i.e. if command developer tried to put "cheese" it would error for obvious reasons
-        for (let i = 0; i < permitted_map_difficulties.length; i++) {
-            if (!this.VALID_DIFFICULTIES.includes(permitted_map_difficulties[i])) {
-                throw new DeveloperCommandError(
-                    `${permitted_map_difficulties[i]} is not a valid map difficulty`
-                );
-            }
-        }
-
-        // If no permitted map difficulties are provided, 
-        // the permitted map difficulties defaults to ALL map difficulties
-        if (permitted_map_difficulties.length === 0) {
-            permitted_map_difficulties = this.VALID_DIFFICULTIES;
-        }
-
-        this.delegateParser = new StringSetValuesParser(
-            ...permitted_map_difficulties.map((d) => d.toLowerCase())
+        this.delegateParser = new LimitedStringSetValuesParser(
+            this.type(),
+            Aliases.allMapDifficulties(),
+            permitted_map_difficulties.map(d => d.toLowerCase()),
         );
     }
 

--- a/parser/map-parser.js
+++ b/parser/map-parser.js
@@ -14,8 +14,8 @@ module.exports = class MapParser {
 
     constructor(...permitted_maps) {
         this.delegateParser = new LimitedStringSetValuesParser(
-            Aliases.allMaps(),
             this.type(),
+            Aliases.allMaps(),
             permitted_maps.map((d) => d.toLowerCase()),
             this.errorMessage
         );

--- a/parser/map-parser.js
+++ b/parser/map-parser.js
@@ -5,19 +5,11 @@ module.exports = class MapParser {
         return 'map';
     }
 
-    errorMessage(badValue) {
-        let msg = ''
-        msg += `${badValue} is neither a map nor a map alias. Valid examples include \`logs\`, \`CUBE\`, \`bLoOdLeS\`, etc. `;
-        msg += 'Use `q!alias <proper_map_name>` to learn map-name shorthands.'
-        return msg;
-    }
-
     constructor(...permitted_maps) {
         this.delegateParser = new LimitedStringSetValuesParser(
             this.type(),
             Aliases.allMaps(),
-            permitted_maps.map((d) => d.toLowerCase()),
-            this.errorMessage
+            permitted_maps.map(d => d.toLowerCase()),
         );
     }
 

--- a/parser/map-parser.js
+++ b/parser/map-parser.js
@@ -1,28 +1,23 @@
-StringSetValuesParser = require('./string-set-values-parser.js');
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
 
 module.exports = class MapParser {
     type() {
         return 'map';
     }
 
+    errorMessage(badValue) {
+        let msg = ''
+        msg += `${badValue} is neither a map nor a map alias. Valid examples include \`logs\`, \`CUBE\`, \`bLoOdLeS\`, etc. `;
+        msg += 'Use `q!alias <proper_map_name>` to learn map-name shorthands.'
+        return msg;
+    }
+
     constructor(...permitted_maps) {
-        // permitted maps must be a subset of valid maps
-        // i.e. if command developer tried to put "cheese" it would error for obvious reasons
-        for (let i = 0; i < permitted_maps.length; i++) {
-            if (!Aliases.allMaps().includes(permitted_maps[i])) {
-                throw new DeveloperCommandError(
-                    `${permitted_maps[i]} is not a valid map`
-                );
-            }
-        }
-
-        // If no permitted maps are provided, the permitted maps defaults to ALL maps
-        if (permitted_maps.length === 0) {
-            permitted_maps = Aliases.allMaps();
-        }
-
-        this.delegateParser = new StringSetValuesParser(
-            ...permitted_maps.map((d) => d.toLowerCase())
+        this.delegateParser = new LimitedStringSetValuesParser(
+            Aliases.allMaps(),
+            this.type(),
+            permitted_maps.map((d) => d.toLowerCase()),
+            this.errorMessage
         );
     }
 

--- a/parser/mode-parser.js
+++ b/parser/mode-parser.js
@@ -1,32 +1,15 @@
-const StringSetValuesParser = require('./string-set-values-parser.js');
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
 
 module.exports = class ModeParser {
     type() {
         return 'mode';
     }
 
-    // permitted modes must be a subset of valid modes
-    // i.e. if command developer tried to put "cheese" it would error for obvious reasons
     constructor(...permitted_modes) {
-        for (let i = 0; i < permitted_modes.length; i++) {
-            if (
-                !Aliases.allModes().includes(permitted_modes[i].toLowerCase())
-            ) {
-                throw new DeveloperCommandError(
-                    `${permitted_modes[i]} is not a valid gamemode`
-                );
-            }
-        }
-
-        // If no permitted modes are provided, the permitted modes defaults to ALL modes
-        if (permitted_modes.length === 0) {
-            permitted_modes = Aliases.allModes();
-        }
-
-        // ModeParser is just a specific instance of StringSetValuesParser with some additional validation
-        // Decided to run with composition over inheritance because inheritance constructor rules are disgusting.
-        this.delegateParser = new StringSetValuesParser(
-            ...permitted_modes.map((m) => m.toLowerCase())
+        this.delegateParser = new LimitedStringSetValuesParser(
+            this.type(),
+            Aliases.allModes(),
+            permitted_modes.map(d => d.toLowerCase()),
         );
     }
 

--- a/parser/number-parser.js
+++ b/parser/number-parser.js
@@ -32,17 +32,17 @@ module.exports = class NumberParser {
     }
 
     parse(arg) {
-        arg = Number(arg);
+        const n = Number(arg);
         // Validate arg
-        if (isNaN(arg)) {
+        if (isNaN(n)) {
             throw new UserCommandError(`Expected number but got \`${arg}\``);
         }
 
         // Ensure arg is within bounds
-        if (arg < this.low || arg > this.high) {
-            throw new UserCommandError(`\`${arg}\` must be between ${this.low} and ${this.high} inclusive`);
+        if (n < this.low || n > this.high) {
+            throw new UserCommandError(`\`${n}\` must be between ${this.low} and ${this.high} inclusive`);
         }
 
-        return arg;
+        return n;
     }
 }

--- a/parser/tower-upgrade-parser.js
+++ b/parser/tower-upgrade-parser.js
@@ -1,15 +1,15 @@
-StringSetValuesParser = require('./string-set-values-parser.js');
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
 
 module.exports = class TowerUpgradeParser {
     type() {
         return 'tower_upgrade';
     }
 
-    constructor() {
-        // TowerUpgradeParser is just a specific instance of StringSetValuesParser with some additional validation
-        // Decided to run with composition over inheritance because inheritance constructor rules are disgusting.
-        this.delegateParser = new StringSetValuesParser(
-            ...Aliases.allTowerUpgrades().map(tu => tu.toLowerCase())
+    constructor(...permitted_tower_upgrades) {
+        this.delegateParser = new LimitedStringSetValuesParser(
+            this.type(),
+            Aliases.allTowerUpgrades(),
+            permitted_tower_upgrades.map(d => d.toLowerCase()),
         );
     }
 


### PR DESCRIPTION
**Mainly**:
- Added a `LimitedStringSetValuesParser` which builds on top of `StringSetValuesParser`:
  - Clear and dynamic parsing error messages for inputs that don't match
  - Does all the work that many of the parsers that take a limited set of values (like `HeroParser`, `MapParser`, `MapDifficultyParser`, etc.) were previously doing. These files are now like 20 lines long.

**Additionally**
- Remove unnecessary parentheses in lambda functions
- `allMapDifficulties()` and `allDifficulties()` added to `AliasRepository`.
- A couple of obvious aliases to add
- Bugfix where 3+ word maps couldn't be searched by `q!lcc`