### PR TITLE
Index tower aliases

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -86,6 +86,7 @@ module.exports = class AliasRepository extends Array {
     // Ensure that none of the aliases clash before adding it in
     addAliasGroup(ag) {
         try {
+            ag.aliases = ag.aliases.map(al => this.permuteSeparators(al)).flat()
             this.preventSharedAliases(ag);
         } catch (e) {
             if (e instanceof AliasError) {
@@ -95,6 +96,30 @@ module.exports = class AliasRepository extends Array {
             }
         }
         this.push(ag);
+    }
+
+    // If "spike-o-pult", adds "spike_o_pult", "spike_o-pult", "spike-o_pult", "spike_opult", etc.
+    SEPARATOR_TOKENS = ["_", "-"]
+    JOIN_TOKENS = ["_", "-", ""]
+    permuteSeparators(al) {
+        const tokens = al.split(/_|-/)
+        let aliases = [tokens[0]]        
+
+        for (var i = 1; i < tokens.length; i++) {
+            let new_aliases = []
+            for (var j = 0; j < aliases.length; j++) {
+                for (var k = 0; k < this.JOIN_TOKENS.length; k++) {
+                    new_aliases.push(
+                        aliases[j] + this.JOIN_TOKENS[k] + tokens[i]
+                    );
+                }
+            }
+            aliases = [...new_aliases];
+        }
+
+
+        delete aliases[aliases.findIndex(a => a == al)]
+        return [al].concat(aliases);
     }
 
     // Checks canonical + aliases against all other alias groups' canonical + aliases

--- a/aliases/towers/magic/alchemist.json
+++ b/aliases/towers/magic/alchemist.json
@@ -15,7 +15,7 @@
     "222": ["base_alch", "base_alchemist"],
 
     "300": ["berserker_brew", "bbrew"],
-    "400": ["stronger_stimulant", "stim"],
+    "400": ["stronger_stimulant", "str_stim", "stronger_stim", "stim", "strim"],
     "500": ["permanent_brew", "permabrew", "pbrew", "pb"],
 
     "030": ["conc", "unstable"],

--- a/aliases/towers/magic/alchemist.json
+++ b/aliases/towers/magic/alchemist.json
@@ -12,23 +12,17 @@
         "liquor",
         "intoxicant"
     ],
+    "222": ["base_alch", "base_alchemist"],
+
     "300": ["berserker_brew", "bbrew"],
     "400": ["stronger_stimulant", "stim"],
     "500": ["permanent_brew", "permabrew", "pbrew", "pb"],
+
     "030": ["conc", "unstable"],
     "040": ["tonic", "transforming_tonic", "tt4", "trans_tonic"],
-    "050": [
-        "totaltrans",
-        "tt5",
-        "total_transformation",
-        "total-transformation"
-    ],
-    "003": ["leadtogold", "lead_to_gold", "lead-to-gold"],
-    "004": ["rubbertogold", "rubber_to_gold", "rubber-to-gold"],
-    "005": [
-        "bma",
-        "bloonmaster",
-        "bloon-master-alchemist",
-        "bloon_master_alchemist"
-    ]
+    "050": ["totaltrans","tt5","total_transformation"],
+
+    "003": ["lead_to_gold", "ltg"],
+    "004": ["rubber_to_gold", "rtg"],
+    "005": ["bloon_master_alchemist","bma","bloon_master"]
 }

--- a/aliases/towers/magic/druid.json
+++ b/aliases/towers/magic/druid.json
@@ -1,10 +1,16 @@
 {
     "xyz": ["druid", "drood", "dru"],
-    "500": ["superstorm", "sstorm"],
-    "030": ["jungle"],
-    "040": ["bounty"],
+    "222": ["base_druid"],
+
+    "300": ["druid_of_the_storm", "dots"],
+    "400": ["ball_lightning", "blightning", "ball", "balll"],
+    "500": ["superstorm"],
+
+    "030": ["druid_of_the_jungle", "jungle", "dotj"],
+    "040": ["jungle's_bounty", "bounty", "jbounty", "jb"],
     "050": ["spirit_of_the_forest", "spirit", "sotf"],
+
     "003": ["druid_of_wrath", "dow"],
-    "004": ["poplust", "lust"],
+    "004": ["poplust", "lust", "pop", "popl"],
     "005": ["avatar_of_wrath", "aow"]
 }

--- a/aliases/towers/magic/ninja_monkey.json
+++ b/aliases/towers/magic/ninja_monkey.json
@@ -1,6 +1,16 @@
 {
     "xyz": ["ninja-monkey", "ninja", "n", "ninj", "shuriken"],
+    "222": ["base_ninja", "base_ninja_monkey"],
+    
+    "300": ["double_shot", "dshot", "dub", "doub", "double"],
     "400": ["bloonjitsu", "bloonjitzu", "jitsu", "jitzu", "bj"],
     "500": ["grandmaster_ninja", "gmn", "gm"],
+
+    "030": ["shinobi_tactics", "shinobi", "shin", "chinobi", "tactics", "tact", "tacts"],
+    "040": ["bloon_sabatoge", "sabo"],
+    "050": ["grand_saboteur", "gsabo"],
+
+    "003": ["flash_bomb", "flash", "fbomb"],
+    "004": ["sticky_bomb", "sticky"],
     "005": ["master_bomber", "mb"]
 }

--- a/aliases/towers/magic/ninja_monkey.json
+++ b/aliases/towers/magic/ninja_monkey.json
@@ -11,6 +11,6 @@
     "050": ["grand_saboteur", "gsabo"],
 
     "003": ["flash_bomb", "flash", "fbomb"],
-    "004": ["sticky_bomb", "sticky"],
+    "004": ["sticky_bomb", "sticky", "stick"],
     "005": ["master_bomber", "mb"]
 }

--- a/aliases/towers/magic/ninja_monkey.json
+++ b/aliases/towers/magic/ninja_monkey.json
@@ -2,12 +2,12 @@
     "xyz": ["ninja-monkey", "ninja", "n", "ninj", "shuriken"],
     "222": ["base_ninja", "base_ninja_monkey"],
     
-    "300": ["double_shot", "dshot", "dub", "doub", "double"],
+    "300": ["double_shot", "d-shot", "dub", "doub", "double"],
     "400": ["bloonjitsu", "bloonjitzu", "jitsu", "jitzu", "bj"],
     "500": ["grandmaster_ninja", "gmn", "gm"],
 
     "030": ["shinobi_tactics", "shinobi", "shin", "chinobi", "tactics", "tact", "tacts"],
-    "040": ["bloon_sabatoge", "sabo"],
+    "040": ["bloon_sabotage", "sabo", "b-sabo"],
     "050": ["grand_saboteur", "gsabo"],
 
     "003": ["flash_bomb", "flash", "fbomb"],

--- a/aliases/towers/magic/super_monkey.json
+++ b/aliases/towers/magic/super_monkey.json
@@ -1,11 +1,16 @@
 {
     "xyz": ["super-monkey", "super", "supermonkey"],
-    "222": ["base_super"],
+    "222": ["base_super", "base_super_monkey"],
+
     "300": ["sun_avatar", "sav", "savatar"],
     "400": ["sun_temple", "temple"],
+    "500": ["true_sun_god", "tsg", "vstg"],
+
     "030": ["robo_monkey", "robo"],
     "040": ["tech_terror", "tt", "technological_terror", "technology"],
-    "050": ["the_anti-bloon", "abloon", "anti", "anti-bloon", "anti_bloon"],
+    "050": ["the_anti-bloon", "abloon", "anti", "anti-bloon"],
+
     "003": ["dark_knight", "dk"],
-    "004": ["dark_champion", "dch"]
+    "004": ["dark_champion", "dch"],
+    "005": ["legend_of_the_night", "lotn"]
 }

--- a/aliases/towers/magic/wizard.json
+++ b/aliases/towers/magic/wizard.json
@@ -1,9 +1,16 @@
 {
     "xyz": ["wizard-monkey", "wizard", "apprentice", "wiz"],
+    "222": ["base_wizard", "base_wizard_monkey"],
+
+    "300": ["arcane_mastery", "mastery"],
     "400": ["arcane_spike", "aspike"],
     "500": ["archmage", "arch"],
+
     "030": ["dragon's_breath","dbreath","db"],
     "040": ["summon_phoenix", "sump", "sumpho", "summon"],
     "050": ["wizard_lord_phoenix", "wlp"],
+
+    "003": ["shimmer", "shim"],
+    "004": ["necromancer", "necromancer:_unpopped_army", "necro"],
     "005": ["prince_of_darkness", "pod", "prince"]
 }

--- a/aliases/towers/military/heli_pilot.json
+++ b/aliases/towers/military/heli_pilot.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["heli-pilot", "heli", "helicopter", "helipilot"],
-    "222": ["base_heli_pilot"],
+    "222": ["base heli", "base_heli_pilot"],
 
     "300": ["razor_rotors", "rr"],
     "400": ["apache_dartship", "adart", "dartship", "dship"],

--- a/aliases/towers/military/heli_pilot.json
+++ b/aliases/towers/military/heli_pilot.json
@@ -1,7 +1,16 @@
 {
     "xyz": ["heli-pilot", "heli", "helicopter", "helipilot"],
+    "222": ["base_heli_pilot"],
+
+    "300": ["razor_rotors", "rr"],
     "400": ["apache_dartship", "adart", "dartship", "dship"],
     "500": ["apache_prime", "aprime", "prime", "prim"],
+
+    "030": ["downdraft", "dd"],
+    "040": ["support_chinhook", "chinhook", "support", "chin"],
     "050": ["special_poperations", "marine", "mar"],
-    "005": ["commanche_commander", "comcom", "commcomm"]
+
+    "003": ["moab_shove", "shove"],
+    "004": ["comanche_defense", "cdef"],
+    "005": ["comanche_commander", "comcom", "commcomm"]
 }

--- a/aliases/towers/military/monkey_ace.json
+++ b/aliases/towers/military/monkey_ace.json
@@ -1,9 +1,15 @@
 {
     "xyz": ["monkey-ace", "ace", "pilot", "plane"],
+    "222": ["base_monkey_ace"],
+
+    "300": ["fighter_plane", "fighter", "fplane"],
     "400": ["operation:_dart_storm", "ods"],
     "500": ["sky_shredder", "shredder", "shred"],
+
+    "030": ["bomber_ace", "bomber"],
     "040": ["ground_zero", "gz"],
     "050": ["tsar_bomba", "tb", "tsar", "bomba", "bombagang"],
+    
     "003": ["neva-miss_targeting", "nevamiss", "neva", "nm"],
     "004": ["spectre", "spect"],
     "005": ["flying_fortress", "ff", "big_plane"]

--- a/aliases/towers/military/monkey_ace.json
+++ b/aliases/towers/military/monkey_ace.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["monkey-ace", "ace", "pilot", "plane"],
-    "222": ["base_monkey_ace"],
+    "222": ["base ace", "base_monkey_ace"],
 
     "300": ["fighter_plane", "fighter", "fplane"],
     "400": ["operation:_dart_storm", "ods"],

--- a/aliases/towers/military/monkey_buccaneer.json
+++ b/aliases/towers/military/monkey_buccaneer.json
@@ -1,8 +1,16 @@
 {
     "xyz": ["monkey-buccaneer", "boat", "buc", "bucc", "buccaneer"],
+    "222": ["base_monkey_buccaneer"],
+
     "300": ["destroyer", "dest", "dd"],
     "400": ["aircraft_carrier", "aircraft", "air"],
     "500": ["carrier_flagship", "carrier", "flagship", "flag"],
+
+    "030": ["cannon_ship"],
     "040": ["monkey_pirates", "mpir"],
-    "050": ["pirate_lord", "plord", "pl"]
+    "050": ["pirate_lord", "plord", "pl"],
+
+    "003": ["merchantman", "merchant", "merch"],
+    "004": ["favored_trades", "flavored", "flavored_trades", "fave"],
+    "005": ["trade_empire", "empire", "emp"],
 }

--- a/aliases/towers/military/monkey_buccaneer.json
+++ b/aliases/towers/military/monkey_buccaneer.json
@@ -1,8 +1,8 @@
 {
     "xyz": ["monkey-buccaneer", "boat", "buc", "bucc", "buccaneer"],
-    "222": ["base_monkey_buccaneer"],
+    "222": ["base_buccaneer", "base_monkey_buccaneer"],
 
-    "300": ["destroyer", "dest", "dd"],
+    "300": ["destroyer", "dest"],
     "400": ["aircraft_carrier", "aircraft", "air"],
     "500": ["carrier_flagship", "carrier", "flagship", "flag"],
 
@@ -12,5 +12,5 @@
 
     "003": ["merchantman", "merchant", "merch"],
     "004": ["favored_trades", "flavored", "flavored_trades", "fave"],
-    "005": ["trade_empire", "empire", "emp"],
+    "005": ["trade_empire", "empire", "emp"]
 }

--- a/aliases/towers/military/monkey_sub.json
+++ b/aliases/towers/military/monkey_sub.json
@@ -10,7 +10,7 @@
     "040": ["first_strike_capability", "first_strike", "fs", "fstrike"],
     "050": ["pre-emptive_strike", "pre", "prestrike", "pstrike"],
 
-    "003": ["triple_guns", "triple", "tguns"],
+    "003": ["triple_guns", "triple", "t_guns", "trip_guns"],
     "004": ["armor_piercing_darts", "ap", "apd", "ad_darts", "apdarts"],
     "005": ["sub_commander", "subcom", "sc", "scom", "scomm"]
 }

--- a/aliases/towers/military/monkey_sub.json
+++ b/aliases/towers/military/monkey_sub.json
@@ -1,9 +1,9 @@
 {
     "xyz": ["monkey-sub", "submarine", "sub"],
-    "222": ["base_sub"],
+    "222": ["base_sub", "base_monkey_sub"],
 
     "300": ["submerge_and_support", "sas", "submerge"],
-    "400": ["bloontonium_reactor", "react", "reactor", "rr"],
+    "400": ["bloontonium_reactor", "react", "reactor"],
     "500": ["energizer", "engz", "egz"],
 
     "030": ["ballistic_missile", "balm", "bmiss", "bmissile"],

--- a/aliases/towers/military/mortar_monkey.json
+++ b/aliases/towers/military/mortar_monkey.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["mortar-monkey", "mortar", "mor"],
-    "222": ["base_mortar_monkey"],
+    "222": ["base_mortar", "base_mortar_monkey"],
 
     "300": ["shell_shock", "sshock"],
     "400": ["the_big_one", "bigone", "big", "tbo"],

--- a/aliases/towers/military/mortar_monkey.json
+++ b/aliases/towers/military/mortar_monkey.json
@@ -1,8 +1,16 @@
 {
     "xyz": ["mortar-monkey", "mortar", "mor"],
+    "222": ["base_mortar_monkey"],
+
+    "300": ["shell_shock", "sshock"],
     "400": ["the_big_one", "bigone", "big", "tbo"],
     "500": ["the_biggest_one", "tb1"],
+
+    "030": ["heavy_shells", "heavy"],
     "040": ["artillery_battery", "art", "artillery"],
     "050": ["pop_and_awe", "paa"],
+
+    "003": ["signal_flare", "signal", "flare"],
+    "004": ["shattering_shells", "sshells", "shattering", "shatt", "shat", "shatter"],
     "005": ["blooncineration", "blooncin", "bcin"]
 }

--- a/aliases/towers/military/sniper_monkey.json
+++ b/aliases/towers/military/sniper_monkey.json
@@ -1,16 +1,16 @@
 {
     "xyz": ["sniper-monkey", "sniper", "sn", "snip", "snooper", "snipermonkey"],
-    "222": ["base_sniper"],
+    "222": ["base_sniper", "base_sniper_monkey"],
 
-    "300": ["deadly_precision", "deadly", "precision", "deadlyprecision", "deadly-precision"],
+    "300": ["deadly_precision", "dprecision", "precision", "deadlyprecision"],
     "400": ["maim_moab", "maim", "maimoab", "maimmoab", "mainmoan"],
-    "500": ["cripple_moab", "cripple", "cripplemoab", "cripple-moab"],
+    "500": ["cripple_moab", "cripple", "cripplemoab"],
 
-    "030": ["bouncing_bullet", "bouncing", "bouncingbullet", "bb", "bouncing-bullet"],
+    "030": ["bouncing_bullet", "bouncing", "bouncingbullet", "bb"],
     "040": ["supply_drop", "supplydrop", "supply", "sd"],
-    "050": ["elite_sniper", "es", "esniper", "elitesniper", "elite-sniper"],
+    "050": ["elite_sniper", "es", "esniper", "elitesniper"],
     
-    "003": ["semi_automatic", "semi", "semiauto", "semi-automatic"],
-    "004": ["fully_automatic", "fullauto", "fullyauto", "fully-automatic"],
+    "003": ["semi_automatic", "semi", "semiauto"],
+    "004": ["fully_automatic", "fullauto", "fullyauto"],
     "005": ["elite_defender", "ed"]
 }

--- a/aliases/towers/military/sniper_monkey.json
+++ b/aliases/towers/military/sniper_monkey.json
@@ -1,11 +1,15 @@
 {
     "xyz": ["sniper-monkey", "sniper", "sn", "snip", "snooper", "snipermonkey"],
+    "222": ["base_sniper"],
+
     "300": ["deadly_precision", "deadly", "precision", "deadlyprecision", "deadly-precision"],
     "400": ["maim_moab", "maim", "maimoab", "maimmoab", "mainmoan"],
     "500": ["cripple_moab", "cripple", "cripplemoab", "cripple-moab"],
+
     "030": ["bouncing_bullet", "bouncing", "bouncingbullet", "bb", "bouncing-bullet"],
     "040": ["supply_drop", "supplydrop", "supply", "sd"],
     "050": ["elite_sniper", "es", "esniper", "elitesniper", "elite-sniper"],
+    
     "003": ["semi_automatic", "semi", "semiauto", "semi-automatic"],
     "004": ["fully_automatic", "fullauto", "fullyauto", "fully-automatic"],
     "005": ["elite_defender", "ed"]

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["bomb-shooter", "bs", "cannon", "bomb"],
-    "222": ["base_bomb_shooter"],
+    "222": ["base_cannon", "base_bomb_shooter"],
 
     "300": ["really_big_bombs", "rbb"],
     "400": ["bloon_impact", "impact"],

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -1,5 +1,16 @@
 {
     "xyz": ["bomb-shooter", "bs", "cannon", "bomb"],
+    "222": ["base_bomb_shooter"],
+
+    "300": ["really_big_bombs", "rbb"],
+    "400": ["bloon_impact", "impact"],
+    "500": ["bloon_crush", "crush", "crunch", "bcrush"],
+
+    "030": ["moab_mauler", "mauler", "maul", "golden_shark"],
+    "040": ["moab_assassin", "assassin", "ass", "black_shark"],
+    "050": ["moab_eliminator", "elim", "moab_elim"],
+    
+    "003": ["cluster_bombs", "cluster"],
     "004": ["recursive_cluster", "recursive", "clusters", "recurs", "recurse", "recur"],
     "005": ["bomb_blitz", "blitz", "bblitz"]
 }

--- a/aliases/towers/primary/boomerang_monkey.json
+++ b/aliases/towers/primary/boomerang_monkey.json
@@ -1,10 +1,10 @@
 {
     "xyz": ["boomerang-monkey","boomerang","boomer","bm","boom","💥","rang","bomerang","boo","bomer","rangs","bomerrang"],
-    "222": ["base_boomerang"],
+    "222": ["base_boomerang", "base_boomerang_monkey"],
 
     "300": ["glaive_richochet", "richochet", "rich", "rick"],
     "400": ["m.o.a.r_glaives", "moar", "more"],
-    "500": ["glaive_lord", "glaive-lord", "glord", "gl", "glaives"],
+    "500": ["glaive_lord", "glord", "gl", "glaives"],
 
     "030": ["bionic_boomerang", "bionic", "bio"],
     "040": ["turbo_charge", "turbo", "tchar", "tcharge"],

--- a/aliases/towers/primary/boomerang_monkey.json
+++ b/aliases/towers/primary/boomerang_monkey.json
@@ -1,7 +1,16 @@
 {
     "xyz": ["boomerang-monkey","boomerang","boomer","bm","boom","💥","rang","bomerang","boo","bomer","rangs","bomerrang"],
+    "222": ["base_boomerang"],
+
+    "300": ["glaive_richochet", "richochet", "rich", "rick"],
+    "400": ["m.o.a.r_glaives", "moar", "more"],
     "500": ["glaive_lord", "glaive-lord", "glord", "gl", "glaives"],
+
+    "030": ["bionic_boomerang", "bionic", "bio"],
     "040": ["turbo_charge", "turbo", "tchar", "tcharge"],
     "050": ["perma_charge", "pcharge", "pc"],
+    
+    "003": ["kylie_boomerang", "kylie", "kyle", "kyl"],
+    "004": ["moab_press", "press"],
     "005": ["moab_domination", "moabdom", "mdom", "domination"]
 }

--- a/aliases/towers/primary/dart_monkey.json
+++ b/aliases/towers/primary/dart_monkey.json
@@ -1,6 +1,16 @@
 {
     "xyz": ["dart-monkey", "dart", "dm"],
-    "500": ["ultra-juggernaut", "ultra_juggernaut", "ultra", "jug", "jugg", "ujug", "uj"],
+    "222": ["base_dart"],
+
+    "300": ["spike-o-pult", "pult", "cat", "cata", "cato", "spikepult", "spult"],
+    "400": ["juggernaut", "jugg", "jug", "naut"],
+    "500": ["ultra-juggernaut", "ultra_juggernaut", "ultra", "ujug", "uj"],
+
+    "030": ["triple_shot", "trip", "tripshot", "tdarts", "tdart"],
     "040": ["super_monkey_fan_club", "smfc"],
-    "005": ["crossbow_master", "xbm", "xbow", "crossbow"]
+    "050": ["plasma_monkey_fan_club", "pmfc"],
+
+    "003": ["crossbow", "xbow"],
+    "004": ["sharp_shooter", "sshot", "sshoot"],
+    "005": ["crossbow_master", "xbm"]
 }

--- a/aliases/towers/primary/dart_monkey.json
+++ b/aliases/towers/primary/dart_monkey.json
@@ -1,10 +1,10 @@
 {
     "xyz": ["dart-monkey", "dart", "dm"],
-    "222": ["base_dart"],
+    "222": ["base_dart", "base_dart_monkey"],
 
     "300": ["spike-o-pult", "pult", "cat", "cata", "cato", "spikepult", "spult"],
     "400": ["juggernaut", "jugg", "jug", "naut"],
-    "500": ["ultra-juggernaut", "ultra_juggernaut", "ultra", "ujug", "uj"],
+    "500": ["ultra-juggernaut", "ultra", "ujug", "uj"],
 
     "030": ["triple_shot", "trip", "tripshot", "tdarts", "tdart"],
     "040": ["super_monkey_fan_club", "smfc"],

--- a/aliases/towers/primary/dart_monkey.json
+++ b/aliases/towers/primary/dart_monkey.json
@@ -11,6 +11,6 @@
     "050": ["plasma_monkey_fan_club", "pmfc"],
 
     "003": ["crossbow", "xbow"],
-    "004": ["sharp_shooter", "sshot", "sshoot"],
-    "005": ["crossbow_master", "xbm"]
+    "004": ["sharp_shooter", "sharp", "sharp_shot", "sshot", "sshoot"],
+    "005": ["crossbow_master", "xbm"] 
 }

--- a/aliases/towers/primary/glue_gunner.json
+++ b/aliases/towers/primary/glue_gunner.json
@@ -1,4 +1,16 @@
 {
     "xyz": ["glue-gunner", "glue", "gg"],
-    "500": ["the_bloon_solver", "bsol", "solv", "solver", "solve"]
+    "222": ["base_glue_gunner"],
+    
+    "300": ["bloon_dissolver", "diss"],
+    "400": ["bloon_liquefier", "liq"],
+    "500": ["the_bloon_solver", "bsol", "solv", "solver", "solve"],
+
+    "030": ["glue_hose", "hose", "ghose"],
+    "040": ["glue_strike", "gstr", "gstrike", "glike"],
+    "050": ["glue_storm", "gs", "glorm"],
+
+    "003": ["moab_glue", "mglue"],
+    "004": ["relentless_glue", "relentless", "relent", "rel", "relglue"],
+    "005": ["super_glue", "sglue"]
 }

--- a/aliases/towers/primary/glue_gunner.json
+++ b/aliases/towers/primary/glue_gunner.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["glue-gunner", "glue", "gg"],
-    "222": ["base_glue_gunner"],
+    "222": ["base_glue", "base_glue_gunner"],
     
     "300": ["bloon_dissolver", "diss"],
     "400": ["bloon_liquefier", "liq"],

--- a/aliases/towers/primary/ice_monkey.json
+++ b/aliases/towers/primary/ice_monkey.json
@@ -1,4 +1,16 @@
 {
     "xyz": ["ice-monkey", "ice", "im"],
+    "222": ["base_ice_monkey"],
+
+    "300": ["ice_shards", "shards", "ishards"],
+    "400": ["embrittlement", "brittle", "brit", "brittlement"],
+    "500": ["super_brittle", "sbrit", "sbrittle", "super_brit"],
+
+    "030": ["arctic_wind", "wind", "arctic"],
+    "040": ["snowstorm", "snow"],
+    "050": ["absolute_zero", "az"],
+    
+    "003": ["cryo_cannon", "cryo"],
+    "004": ["icicles", "icy"],
     "005": ["icicle_impale", "impale", "iimpale", "impa"]
 }

--- a/aliases/towers/primary/ice_monkey.json
+++ b/aliases/towers/primary/ice_monkey.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["ice-monkey", "ice", "im"],
-    "222": ["base_ice_monkey"],
+    "222": ["base_ice", "base_ice_monkey"],
 
     "300": ["ice_shards", "shards", "ishards"],
     "400": ["embrittlement", "brittle", "brit", "brittlement"],

--- a/aliases/towers/primary/tack_shooter.json
+++ b/aliases/towers/primary/tack_shooter.json
@@ -1,7 +1,16 @@
 {
     "xyz": ["tack-shooter", "tac", "tak", "ta", "tacc", "tack"],
+    "222": ["base_tack"],
+
+    "300": ["hot_shots", "hshots"],
+    "400": ["ring_of_fire", "rof"],
     "500": ["inferno_ring", "inferno", "iring", "ir"],
+
+    "030": ["blade_shooter", "blades", "blade", "blad"],
+    "040": ["blade_maelstrom", "mael", "bmal", "blam"],
     "050": ["super_maelstrom", "smael", "who", "who?", "smaelstrom", "smal"],
+
+    "003": ["tack_sprayer", "spray", "sprayer"],
     "004": ["overdrive", "od", "odrive"],
     "005": ["the_tack_zone", "tz", "tzone", "tackzone", "tack_zone"]
 }

--- a/aliases/towers/primary/tack_shooter.json
+++ b/aliases/towers/primary/tack_shooter.json
@@ -1,6 +1,6 @@
 {
     "xyz": ["tack-shooter", "tac", "tak", "ta", "tacc", "tack"],
-    "222": ["base_tack"],
+    "222": ["base_tack", "base_tack_shooter"],
 
     "300": ["hot_shots", "hshots"],
     "400": ["ring_of_fire", "rof"],

--- a/aliases/towers/support/banana_farm.json
+++ b/aliases/towers/support/banana_farm.json
@@ -1,0 +1,16 @@
+{
+    "xyz": ["monkey_farm", "farm"],
+    "222": ["base_farm", "base_banana_farm"],
+
+    "300": ["banana_plantation", "plantation", "plant"],
+    "400": ["banana_research_facility", "research", "facility"],
+    "500": ["banana_central", "bcent"],
+
+    "030": ["monkey_bank", "bank"],
+    "040": ["imf_loan", "imf"],
+    "050": ["monkey-nomics", "nomics", "economics"],
+
+    "003": ["marketplace", "place"],
+    "004": ["central_market", "cmarket"],
+    "005": ["monkey_wall_street", "wall_street", "wall"]
+}

--- a/aliases/towers/support/engineer.json
+++ b/aliases/towers/support/engineer.json
@@ -1,5 +1,16 @@
 {
     "xyz": ["engineer_monkey","engineer","engie","engi","eng","engie"],
+    "222": ["base_engineer", "base_engineer_monkey"],
+
+    "300": ["sprockets", "sproc", "sprock", "sproct"],
+    "400": ["sentry_expert", "sexpert"],
     "500": ["sentry_paragon", "para", "paragon"],
+
+    "030": ["cleansing_foam", "cleansing", "foam", "cfoam"],
+    "040": ["overclock", "oc"],
+    "050": ["ultraboost", "uboost"],
+
+    "003": ["double_gun", "dgun"],
+    "004": ["bloon_trap", "btrap"],
     "005": ["xxxl_trap", "xxl", "xl", "xtrap", "xxl_trap", "xxxl"]
 }

--- a/aliases/towers/support/engineer.json
+++ b/aliases/towers/support/engineer.json
@@ -6,7 +6,7 @@
     "400": ["sentry_expert", "sexpert"],
     "500": ["sentry_paragon", "para", "paragon"],
 
-    "030": ["cleansing_foam", "cleansing", "foam", "cfoam"],
+    "030": ["cleansing_foam", "cleansing", "foam", "cfoam", "clean", "cleans", "cleanse"],
     "040": ["overclock", "oc"],
     "050": ["ultraboost", "uboost"],
 

--- a/aliases/towers/support/monkey_village.json
+++ b/aliases/towers/support/monkey_village.json
@@ -1,5 +1,16 @@
 {
     "xyz": ["monkey_village", "village", "vil", "vill", "mvil"],
+    "222": ["base_village", "base_monkey_village"],
+
+    "300": ["primary_training", "ptraining", "ptrain"],
+    "400": ["primary_mentoring", "pment", "pmentoring"],
     "500": ["primary_expertise", "pe", "primex"],
-    "050": ["homeland_defense", "homeland_defence", "homeland", "hd"]
+
+    "030": ["monkey_intelligence_bureau", "mib"],
+    "040": ["call_to_arms", "cta"],
+    "050": ["homeland_defense", "homeland_defence", "homeland", "hd"],
+
+    "003": ["monkey_town", "mtown"],
+    "004": ["monkey_city", "mcity", "city"],
+    "005": ["monkeyopolis", "opolis"]
 }

--- a/aliases/towers/support/spike_factory.json
+++ b/aliases/towers/support/spike_factory.json
@@ -1,5 +1,16 @@
 {
-    "xyz": ["spike_factory","factory","spike","spac","spak","spanc","spikes","spikefactory","spi","sf","spacc","spikeshooter","basetrash","spact","spactory"],
-    "005": ["perma-spike", "permaspike", "pspike"],
-    "050": ["carpet_of_spikes", "cos", "carpet", "carpetofspikes"]
+    "xyz": ["spike-factory","factory","spike","spac","spak","spanc","spikes","spikefactory","spi","sf","spacc","spikeshooter","basetrash","spact","spactory"],
+    "222": ["base_spike"],
+
+    "300": ["spiked_balls", "sballs"],
+    "400": ["spiked_mines", "spines"],
+    "500": ["super_mines", "swines"],
+
+    "030": ["moab_shredr", "moab_shredder"],
+    "040": ["spike_storm"],
+    "050": ["carpet_of_spikes", "cos", "carpet", "carpetofspikes"],
+
+    "003": ["long_life_spikes", "ll", "lls"],
+    "004": ["deadly_spikes", "deadly", "dspikes"],
+    "005": ["perma-spike", "permaspike", "pspike"]
 }

--- a/commands/index-3tcabr.js
+++ b/commands/index-3tcabr.js
@@ -427,7 +427,9 @@ async function displayOG3TCABRFromTowers(message, towers, combo) {
 
     // Order towers in completion order
     titleTowers = [combo.TOWER_1, combo.TOWER_2, combo.TOWER_3];
-    titleTowers = titleTowers.filter((tt) => towers.includes(tt));
+    titleTowers = titleTowers.filter(
+        (tt) => towers.map(t => t.toLowerCase()).includes(tt.toLowerCase())
+    );
 
     return embed(
         message,


### PR DESCRIPTION
Filled out the rest of the index-relevant aliases (no tier 1s or tier 2s yet, will need those later for sure!)

Also, aliases with `_`s and `-`s are permuted in the following way:

`spike-o-pult` =>`'spike-o-pult', 'spike_o_pult', 'spike_o-pult', 'spike_opult', 'spike-o_pult', 'spike-opult', 'spikeo_pult',  'spikeo-pult'`

That is `-` and `_` get mapped to each `-`, `_` and the empty string/token. (Note: it doesn't work on the base tower name, which gets populated from the filename). This makes it even easier for the user to enter the name right. This applies to _all_ aliases, not just towers!