### PR TITLE
q!3tcabr fixes

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -80,6 +80,16 @@ module.exports = class AliasRepository extends Array {
                 sourcefile: f,
             };
             this.addAliasGroup(nextAliasGroup);
+
+            // Hack to add appropriate base tower entry
+            if (upgrade == 'xyz') {
+                const baseTowerAliasGroup = {
+                    canonical: `${baseName}#222`,
+                    aliases: [baseName].concat(towerUpgrades['xyz']).map(al => `base_${al}`),
+                    sourcefile: f,
+                }
+                this.addAliasGroup(baseTowerAliasGroup);
+            }
         }
     }
 

--- a/alias-repository.js
+++ b/alias-repository.js
@@ -6,12 +6,12 @@ module.exports = class AliasRepository extends Array {
     // Configuration/Initialization
     ////////////////////////////////////////////////////
 
-    // {source_directory: handling function}
-    SPECIAL_HANDLING_CASES = {
-        './aliases/towers': this.loadTowerAliasFile,
-    };
-
     asyncAliasFiles() {
+        // {source_directory: handling function}
+        const SPECIAL_HANDLING_CASES = {
+            './aliases/towers': this.loadTowerAliasFile,
+        };
+
         (async () => {
             for await (const absolutePath of Files.getFiles('./aliases', [
                 '.json',
@@ -31,9 +31,9 @@ module.exports = class AliasRepository extends Array {
                 let handlingFunction = this.loadAliasFile;
 
                 // See if the file has a special handler
-                for (const specialRelPath in this.SPECIAL_HANDLING_CASES) {
+                for (const specialRelPath in SPECIAL_HANDLING_CASES) {
                     if (relPath.startsWith(specialRelPath)) {
-                        handlingFunction = this.SPECIAL_HANDLING_CASES[
+                        handlingFunction = SPECIAL_HANDLING_CASES[
                             specialRelPath
                         ];
                         break;
@@ -109,18 +109,19 @@ module.exports = class AliasRepository extends Array {
     }
 
     // If "spike-o-pult", adds "spike_o_pult", "spike_o-pult", "spike-o_pult", "spike_opult", etc.
-    SEPARATOR_TOKENS = ["_", "-"]
-    JOIN_TOKENS = ["_", "-", ""]
     permuteSeparators(al) {
-        const tokens = al.split(/_|-/)
+        const SEPARATOR_TOKENS = ["_", "-"]
+        const JOIN_TOKENS = ["_", "-", ""]
+
+        const tokens = al.split(new RegExp(SEPARATOR_TOKENS.join('|')))
         let aliases = [tokens[0]]        
 
         for (var i = 1; i < tokens.length; i++) {
             let new_aliases = []
             for (var j = 0; j < aliases.length; j++) {
-                for (var k = 0; k < this.JOIN_TOKENS.length; k++) {
+                for (var k = 0; k < JOIN_TOKENS.length; k++) {
                     new_aliases.push(
-                        aliases[j] + this.JOIN_TOKENS[k] + tokens[i]
+                        aliases[j] + JOIN_TOKENS[k] + tokens[i]
                     );
                 }
             }
@@ -253,17 +254,23 @@ module.exports = class AliasRepository extends Array {
         return modes.map((ag) => ag.canonical);
     }
 
-    TOWER_CANONICAL_REGEX = /[a-z]#\d\d\d/i;
-
     allTowerUpgrades() {
+        const TOWER_CANONICAL_REGEX = /[a-z]#\d\d\d/i;
+
         let upgrades = [];
         for (let i = 0; i < this.length; i++) {
             const canonical = this[i].canonical;
-            if (this.TOWER_CANONICAL_REGEX.test(canonical)) {
+            if (TOWER_CANONICAL_REGEX.test(canonical)) {
                 upgrades.push(canonical);
             }
         }
         return upgrades;
+    }
+
+    // Gets all 0-0-0 tower names
+    allTowers() {
+        return this.filter(ag => ag.canonical.endsWith('#300'))
+                   .map(ag => ag.canonical.slice(0, -4))
     }
 
     allHeroes() {

--- a/aliases/towers/magic/alchemist.json
+++ b/aliases/towers/magic/alchemist.json
@@ -12,7 +12,6 @@
         "liquor",
         "intoxicant"
     ],
-    "222": ["base_alch", "base_alchemist"],
 
     "300": ["berserker_brew", "bbrew"],
     "400": ["stronger_stimulant", "str_stim", "stronger_stim", "stim", "strim"],

--- a/aliases/towers/magic/druid.json
+++ b/aliases/towers/magic/druid.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["druid", "drood", "dru"],
-    "222": ["base_druid"],
 
     "300": ["druid_of_the_storm", "dots"],
     "400": ["ball_lightning", "blightning", "ball", "balll"],

--- a/aliases/towers/magic/ninja_monkey.json
+++ b/aliases/towers/magic/ninja_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["ninja-monkey", "ninja", "n", "ninj", "shuriken"],
-    "222": ["base_ninja", "base_ninja_monkey"],
     
     "300": ["double_shot", "d-shot", "dub", "doub", "double"],
     "400": ["bloonjitsu", "bloonjitzu", "jitsu", "jitzu", "bj"],

--- a/aliases/towers/magic/super_monkey.json
+++ b/aliases/towers/magic/super_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["super-monkey", "super", "supermonkey"],
-    "222": ["base_super", "base_super_monkey"],
 
     "300": ["sun_avatar", "sav", "savatar"],
     "400": ["sun_temple", "temple"],

--- a/aliases/towers/magic/wizard.json
+++ b/aliases/towers/magic/wizard.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["wizard-monkey", "wizard", "apprentice", "wiz"],
-    "222": ["base_wizard", "base_wizard_monkey"],
 
     "300": ["arcane_mastery", "mastery"],
     "400": ["arcane_spike", "aspike"],

--- a/aliases/towers/military/heli_pilot.json
+++ b/aliases/towers/military/heli_pilot.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["heli-pilot", "heli", "helicopter", "helipilot"],
-    "222": ["base heli", "base_heli_pilot"],
 
     "300": ["razor_rotors", "rr"],
     "400": ["apache_dartship", "adart", "dartship", "dship"],

--- a/aliases/towers/military/monkey_ace.json
+++ b/aliases/towers/military/monkey_ace.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["monkey-ace", "ace", "pilot", "plane"],
-    "222": ["base ace", "base_monkey_ace"],
 
     "300": ["fighter_plane", "fighter", "fplane"],
     "400": ["operation:_dart_storm", "ods"],

--- a/aliases/towers/military/monkey_buccaneer.json
+++ b/aliases/towers/military/monkey_buccaneer.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["monkey-buccaneer", "boat", "buc", "bucc", "buccaneer"],
-    "222": ["base_buccaneer", "base_monkey_buccaneer"],
 
     "300": ["destroyer", "dest"],
     "400": ["aircraft_carrier", "aircraft", "air"],

--- a/aliases/towers/military/monkey_sub.json
+++ b/aliases/towers/military/monkey_sub.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["monkey-sub", "submarine", "sub"],
-    "222": ["base_sub", "base_monkey_sub"],
 
     "300": ["submerge_and_support", "sas", "submerge"],
     "400": ["bloontonium_reactor", "react", "reactor"],

--- a/aliases/towers/military/mortar_monkey.json
+++ b/aliases/towers/military/mortar_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["mortar-monkey", "mortar", "mor"],
-    "222": ["base_mortar", "base_mortar_monkey"],
 
     "300": ["shell_shock", "sshock"],
     "400": ["the_big_one", "bigone", "big", "tbo"],

--- a/aliases/towers/military/sniper_monkey.json
+++ b/aliases/towers/military/sniper_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["sniper-monkey", "sniper", "sn", "snip", "snooper", "snipermonkey"],
-    "222": ["base_sniper", "base_sniper_monkey"],
 
     "300": ["deadly_precision", "dprecision", "precision", "deadlyprecision"],
     "400": ["maim_moab", "maim", "maimoab", "maimmoab", "mainmoan"],

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["bomb-shooter", "bs", "cannon", "bomb"],
-    "222": ["base_cannon", "base_bomb_shooter"],
 
     "300": ["really_big_bombs", "rbb"],
     "400": ["bloon_impact", "impact"],

--- a/aliases/towers/primary/boomerang_monkey.json
+++ b/aliases/towers/primary/boomerang_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["boomerang-monkey","boomerang","boomer","bm","boom","💥","rang","bomerang","boo","bomer","rangs","bomerrang"],
-    "222": ["base_boomerang", "base_boomerang_monkey"],
 
     "300": ["glaive_richochet", "richochet", "rich", "rick"],
     "400": ["m.o.a.r_glaives", "moar", "more"],

--- a/aliases/towers/primary/dart_monkey.json
+++ b/aliases/towers/primary/dart_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["dart-monkey", "dart", "dm"],
-    "222": ["base_dart", "base_dart_monkey"],
 
     "300": ["spike-o-pult", "pult", "cat", "cata", "cato", "spikepult", "spult"],
     "400": ["juggernaut", "jugg", "jug", "naut"],

--- a/aliases/towers/primary/glue_gunner.json
+++ b/aliases/towers/primary/glue_gunner.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["glue-gunner", "glue", "gg"],
-    "222": ["base_glue", "base_glue_gunner"],
     
     "300": ["bloon_dissolver", "diss"],
     "400": ["bloon_liquefier", "liq"],

--- a/aliases/towers/primary/ice_monkey.json
+++ b/aliases/towers/primary/ice_monkey.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["ice-monkey", "ice", "im"],
-    "222": ["base_ice", "base_ice_monkey"],
 
     "300": ["ice_shards", "shards", "ishards"],
     "400": ["embrittlement", "brittle", "brit", "brittlement"],

--- a/aliases/towers/primary/tack_shooter.json
+++ b/aliases/towers/primary/tack_shooter.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["tack-shooter", "tac", "tak", "ta", "tacc", "tack"],
-    "222": ["base_tack", "base_tack_shooter"],
 
     "300": ["hot_shots", "hshots"],
     "400": ["ring_of_fire", "rof"],

--- a/aliases/towers/support/banana_farm.json
+++ b/aliases/towers/support/banana_farm.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["monkey_farm", "farm"],
-    "222": ["base_farm", "base_banana_farm"],
 
     "300": ["banana_plantation", "plantation", "plant"],
     "400": ["banana_research_facility", "research", "facility"],

--- a/aliases/towers/support/engineer.json
+++ b/aliases/towers/support/engineer.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["engineer_monkey","engineer","engie","engi","eng","engie"],
-    "222": ["base_engineer", "base_engineer_monkey"],
 
     "300": ["sprockets", "sproc", "sprock", "sproct"],
     "400": ["sentry_expert", "sexpert"],

--- a/aliases/towers/support/monkey_village.json
+++ b/aliases/towers/support/monkey_village.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["monkey_village", "village", "vil", "vill", "mvil"],
-    "222": ["base_village", "base_monkey_village"],
 
     "300": ["primary_training", "ptraining", "ptrain"],
     "400": ["primary_mentoring", "pment", "pmentoring"],

--- a/aliases/towers/support/spike_factory.json
+++ b/aliases/towers/support/spike_factory.json
@@ -1,6 +1,5 @@
 {
     "xyz": ["spike-factory","factory","spike","spac","spak","spanc","spikes","spikefactory","spi","sf","spacc","spikeshooter","basetrash","spact","spactory"],
-    "222": ["base_spike"],
 
     "300": ["spiked_balls", "sballs"],
     "400": ["spiked_mines", "spines"],

--- a/commands/index-3tcabr.js
+++ b/commands/index-3tcabr.js
@@ -407,7 +407,13 @@ async function displayOG3TCABRFromSubsetTowers(message, towers) {
         const comboTowers = [c.TOWER_1, c.TOWER_2, c.TOWER_3].map((t) =>
             t.toLowerCase()
         );
-        return towers.every((t) => comboTowers.includes(t.toLowerCase()));
+        
+        // Make sure that towers is a subset of comboTowers accounting for duplicate tower appearances
+        // in both the queried towers and the existing 3tc abr combos
+        return towers.map(t => t.toLowerCase()).every((t, _, ltowers) =>
+            comboTowers.includes(t) &&
+            ltowers.filter(tt => tt === t).length <= comboTowers.filter(ct => ct === t).length
+        );
     });
 
     if (matchingCombos.length == 0) {

--- a/commands/index-3tcabr.js
+++ b/commands/index-3tcabr.js
@@ -5,6 +5,7 @@ const AnyOrderParser = require('../parser/any-order-parser');
 const OptionalParser = require('../parser/optional-parser');
 const OrParser = require('../parser/or-parser');
 
+const TowerParser = require('../parser/tower-parser.js');
 const TowerUpgradeParser = require('../parser/tower-upgrade-parser.js');
 const HeroParser = require('../parser/hero-parser.js');
 const NaturalNumberParser = require('../parser/natural-number-parser');
@@ -37,7 +38,8 @@ module.exports = {
 
         towerOrHeroParser = new OrParser(
             new TowerUpgradeParser(),
-            new HeroParser()
+            new HeroParser(),
+            new TowerParser(),
         );
 
         const parsed = CommandParser.parse(
@@ -65,6 +67,12 @@ module.exports = {
                 message,
                 parsed.natural_number
             ).catch((e) => err(e, message));
+        } else if (parsed.tower) {
+            const ex_tower_upgrade = Aliases.getAliasGroup(parsed.tower + '#300').aliases[0]
+            return module.exports.errorMessage(
+                message, 
+                [`You must enter a tower upgrade like \`${ex_tower_upgrade}\` rather than a tower like \`${parsed.tower}\``]
+            );
         } else if (parsed.hero || parsed.tower_upgrade) {
             // Tower(s) specified
             towers = null;

--- a/parser/tower-parser.js
+++ b/parser/tower-parser.js
@@ -1,0 +1,20 @@
+LimitedStringSetValuesParser = require('./limited-string-set-values-parser.js');
+
+module.exports = class TowerParser {
+    type() {
+        return 'tower';
+    }
+
+    constructor(...permitted_towers) {
+        this.delegateParser = new LimitedStringSetValuesParser(
+            this.type(),
+            Aliases.allTowers(),
+            permitted_towers.map(d => d.toLowerCase()),
+        );
+    }
+
+    parse(arg) {
+        // Delegate the parsing work to the StringSetValuesParser
+        return this.delegateParser.parse(arg);
+    }
+};


### PR DESCRIPTION
- Base tower (2-2-2) aliases are much more plentiful and are derived from the (0-0-0) tower name
- Attempting to invoke 3tcabr with 0-0-0 tower names will result in an error message
  - Wrote a `TowerParser` for catching tower names
- `q!3tcabr wlp wlp` will recognize that there must be 2 occurrences of wlp in the combo.