### PR TITLE
q!alias improvements

### DIFF
--- a/commands/index-2mp.js
+++ b/commands/index-2mp.js
@@ -386,8 +386,8 @@ async function display2MPTowerStatistics(message, tower) {
         .addField('Base Tower', baseTowerCompletionMarking, true) // Base tower
         .addField('\u200b', '\u200b', true) // Right column placeholder
     
-    for (var path = 1; path <= 3; path++) {
-        for (var tier = 3; tier <=5; tier++) {
+    for (var tier = 3; tier <=5; tier++) {
+        for (var path = 1; path <= 3; path++) {
             towerUpgradeName = Aliases.towerUpgradeFromTowerAndPathAndTier(tower, path, tier);
             upgradeCompletionMarking = await getCompletionMarking(entryRow, path, tier)
             challengeEmbed.addField(towerUpgradeName, upgradeCompletionMarking, true)


### PR DESCRIPTION
**q!alias**:
- No need for `newArgs`
- Arguments come into `q!alias` raw now. Use this pattern for other commands like say a calculator
- 1024 character limit
- `q!alias help` improvements
- `q!alias` parsing minor improvements

**q!2mp**:
- Fix tower layout so that tier increases downwards, path increases to the right.