### PR TITLE
Improve q!alias and make alias loading safer

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -98,7 +98,7 @@ class AliasRepository extends Array {
     addAliasGroup(ag) {
         try {
             // If adora's_temple is an alias, include adoras_temple as well
-            ag.aliases = ag.aliases
+            ag.aliases = [ag.aliases].flat()
                 .concat(ag.canonical)
                 .map((al) => this.permuteRemovalForgettableCharacters(al))
                 .flat();
@@ -457,6 +457,15 @@ class AliasRepository extends Array {
             .split('_')
             .map((tk) => h.toTitleCase(tk))
             .join(' ');
+    }
+
+    ARG_SPLITTER = '#'
+    
+    canonicizeArg(arg) {
+        return arg
+            .split(this.ARG_SPLITTER)
+            .map((t) => Aliases.getCanonicalForm(t) || t)
+            .join(this.ARG_SPLITTER);
     }
 }
 

--- a/aliases/misc.json
+++ b/aliases/misc.json
@@ -1,6 +1,5 @@
 {
-    
-    "discord": "https://discord.gg/VMX5hZA"
     "cheapest": ["cheap", "chp", "chea", "chpst"],
     "user": ["u"],
+    "discord": "https://discord.gg/"
 }

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -1,5 +1,5 @@
 {
-    "xyz": ["bomb", "bomb-shooter", "bs", "cannon", "can"],
+    "xyz": ["bomb", "bomb-shooter", "bs", "cannon", "can", "💣"],
 
     "300": ["really_big_bombs", "rbb"],
     "400": ["bloon_impact", "impact"],

--- a/commands/alias.js
+++ b/commands/alias.js
@@ -20,8 +20,9 @@ module.exports = {
         }
 
         alias = parsed.anything;
+        canonicizedAlias = Aliases.canonicizeArg(alias);
 
-        aliasSet = Aliases.getAliasSet(alias);
+        aliasSet = Aliases.getAliasSet(canonicizedAlias);
         let aliasStr = '';
         if (aliasSet) {
             aliasStr = aliasSet.join(', ');


### PR DESCRIPTION
* Protect against non-list, single string alias entries
* Move arg canonicization responsibility to alias-repository
* Improve `q!alias` by running canonicization on the argument before grabbing the alias set to deal with queries like `q!alias wiz#400`