### PR TITLE
Huge Improvement in Robustness and Reliability of `q!balance`

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -261,7 +261,19 @@ class AliasRepository extends Array {
         let ag = this.getAliasGroup(aliasMember);
         let result = this.filter(
             (otherAliasGroup) => otherAliasGroup.sourcefile === ag.sourcefile
-        );
+        )
+        return result;
+    }
+
+    getAliasGroupsFromSameImmediateDirectoryAs(aliasMember) {
+        aliasMember = aliasMember.toLowerCase();
+        let ag = this.getAliasGroup(aliasMember);
+        let result = this.filter(function (otherAliasGroup) {
+            let agPathTokens = ag.sourcefile.split('/')
+            let otherAgPathTokens = otherAliasGroup.sourcefile.split('/')
+            return agPathTokens[agPathTokens.length - 2] == 
+                    otherAgPathTokens[otherAgPathTokens.length - 2]
+        })
         return result;
     }
 
@@ -355,9 +367,36 @@ class AliasRepository extends Array {
 
     // Gets all 0-0-0 tower names
     allTowers() {
-        return this.filter((ag) => ag.canonical.endsWith('#300')).map((ag) =>
-            ag.canonical.slice(0, -4)
-        );
+        return this.allPrimaryTowers() + this.allMilitaryTowers() + 
+                this.allMagicTowers() + this.allSupportTowers()
+    }
+
+    allPrimaryTowers() {
+        const primaryTowers = this.getAliasGroupsFromSameImmediateDirectoryAs('DART');
+
+        return primaryTowers.map((ag) => ag.canonical)
+                            .filter((upgrade) => !upgrade.includes('#'))
+    }
+
+    allMilitaryTowers() {
+        const militaryTowers = this.getAliasGroupsFromSameImmediateDirectoryAs('HELI');
+
+        return militaryTowers.map((ag) => ag.canonical)
+                            .filter((upgrade) => !upgrade.includes('#'))
+    }
+
+    allMagicTowers() {
+        const magicTowers = this.getAliasGroupsFromSameImmediateDirectoryAs('WIZ');
+
+        return magicTowers.map((ag) => ag.canonical)
+                            .filter((upgrade) => !upgrade.includes('#'))
+    }
+
+    allSupportTowers() {
+        const supportTowers = this.getAliasGroupsFromSameImmediateDirectoryAs('FARM');
+
+        return supportTowers.map((ag) => ag.canonical)
+                            .filter((upgrade) => !upgrade.includes('#'))
     }
 
     allWaterTowers() {
@@ -459,13 +498,11 @@ class AliasRepository extends Array {
             .join(' ');
     }
 
-    ARG_SPLITTER = '#'
-    
     canonicizeArg(arg) {
         return arg
-            .split(this.ARG_SPLITTER)
+            .split('#')
             .map((t) => Aliases.getCanonicalForm(t) || t)
-            .join(this.ARG_SPLITTER);
+            .join('#');
     }
 }
 

--- a/alias-repository.js
+++ b/alias-repository.js
@@ -222,7 +222,7 @@ class AliasRepository extends Array {
 
     // Converts a member of an alias group to its canonical form
     getCanonicalForm(aliasMember) {
-        let ag = this.getAliasGroup(aliasMember);
+        let ag = this.getAliasGroup(aliasMember.toLowerCase());
         if (ag) return ag.canonical;
         else return null;
     }
@@ -367,8 +367,10 @@ class AliasRepository extends Array {
 
     // Gets all 0-0-0 tower names
     allTowers() {
-        return this.allPrimaryTowers() + this.allMilitaryTowers() + 
-                this.allMagicTowers() + this.allSupportTowers()
+        return [].concat(this.allPrimaryTowers())
+                 .concat(this.allMilitaryTowers())
+                 .concat(this.allMagicTowers())
+                 .concat(this.allSupportTowers()) 
     }
 
     allPrimaryTowers() {

--- a/commands/index-balances.js
+++ b/commands/index-balances.js
@@ -97,15 +97,20 @@ async function showBuffNerf(message, tower) {
             balances[v] += nerf
         }
     }
-    console.log(balances)
-    
+
+    formattedTower = Aliases.toIndexNormalForm(tower)
+
     let embed = new Discord.MessageEmbed()
-        .setTitle(`Buffs and Nerfs for ${Aliases.toIndexNormalForm(tower)}\n`)
+        .setTitle(`Buffs and Nerfs for ${formattedTower}\n`)
         .setColor(darkgreen)
     
     for (const version in balances) {
         embed.addField(`v. ${version}`, balances[version] + "\n\u200b")
     }
 
-    message.channel.send(embed);
+    try {
+        await message.channel.send(embed);
+    } catch(e) {
+        return message.channel.send(`Too many balance changes for ${formattedTower}; fix in progress`)
+    }
 }

--- a/commands/index-balances.js
+++ b/commands/index-balances.js
@@ -59,20 +59,19 @@ async function showBuffNerf(message, tower) {
     }
 
     let balances = [];
-    for (i = 0; i < 21; i++) {
-        let buff = sheet.getCellByA1(`${col0}${i + 24}`).note;
-        let nerf = sheet.getCellByA1(`${col1}${i + 24}`).note;
-        if (!buff) buff = 'none';
-        else {
+    for (row = headerRowInex + 1; row < headerRowInex + 1 + currentVersion; row++) {
+        let buff = sheet.getCell(row, entryColIndex).note;
+        let nerf = sheet.getCell(row, entryColIndex + 1).note;
+
+        if (buff) {
             buff = buff.replace(/✔️/g, '✅');
             buff = buff.replace(/\n\n/g, '\n');
         }
-        if (!nerf) nerf = 'none';
-        else {
+        balances.push(buff)
+        if (nerf) {
             nerf = nerf.replace(/\n\n/g, '\n');
         }
-        res = [buff.toString(), nerf.toString()];
-        balances.push(res);
+        balances.push(nerf);
     }
     let embed = new Discord.MessageEmbed()
         .setTitle(`Buffs and Nerfs for ${tower}\n`)

--- a/helpers/google-sheets.js
+++ b/helpers/google-sheets.js
@@ -27,9 +27,29 @@ function sheetByName(doc, title) {
     }
 }
 
+function rowColToA1(row, col) {
+    return `${getA1ColumnName(col)}${row}`
+}
+
+function getA1ColumnName(col)
+{
+    dividend = col;
+    columnName = "";
+
+    while (dividend > 0)
+    {
+        modulo = (dividend - 1) % 26;
+        columnName = String.fromCharCode(65 + modulo) + columnName;
+        dividend = Math.floor((dividend - modulo) / 26);
+    } 
+
+    return columnName;
+}
+
 module.exports = {
     BTD6_INDEX_KEY,
 
     load,
     sheetByName,
+    rowColToA1,
 };


### PR DESCRIPTION
**`q!balance`**
- Use `TowerParser`
- Validate column headers to find balance changes column rather than keep a long list of tower-column mappings
- Neater formatting?
- Help and error messages
- Message for when balance changes are too long

**Also**:
- `AliasRepository` method additions (get all towers of a given category)