### PR TITLE
Smarter error handling when there are too few or too many arguments

### DIFF
--- a/aliases/towers/magic/wizard_monkey.json
+++ b/aliases/towers/magic/wizard_monkey.json
@@ -5,7 +5,7 @@
     "400": ["arcane_spike", "aspike"],
     "500": ["archmage", "arch"],
 
-    "030": ["dragon's_breath","dbreath","db"],
+    "030": ["dragon's_breath","dbreath","db", "dragon's", "breath"],
     "040": ["summon_phoenix", "sump", "sumpho", "summon"],
     "050": ["wizard_lord_phoenix", "wlp"],
 

--- a/helpers/general.js
+++ b/helpers/general.js
@@ -46,6 +46,27 @@ function allLengthNPermutations(inputArr) {
     return result;
 }
 
+// [1, 2, 3], 5 => [null, null, 1, 2, 3], [null, 1, null, 2, 3], [null, 1, 2, null, 3], [null, 1, 2, 3, null], [1, null, null, 2, 3], etc.
+function permutatePaddings(arr, newLength) {
+    const numPads = newLength - arr.length;
+    
+    if (numPads <= 0) return [arr];
+    
+    let results = []
+
+    for (var i = 0; i < arr.length + 1; i++) {
+        endArr = arr.slice(i)
+        const recursiveResults = permutatePaddings(endArr, endArr.length + numPads - 1)
+        for (var j = 0; j < recursiveResults.length; j++) {
+            results.push(
+                arr.slice(0, i).concat(null).concat(recursiveResults[j])
+            )
+        }
+    }
+
+    return results;
+}
+
 function shuffle(inputArr) {
     arr = [...inputArr];
     for (let i = arr.length - 1; i > 0; i--) {
@@ -132,6 +153,7 @@ module.exports = {
     numberAsCost,
     randomIntegerFromInclusiveRange,
     allLengthNPermutations,
+    permutatePaddings,
     shuffle,
     range,
     toOrdinalSuffix,


### PR DESCRIPTION
Should make errors MUCH cleaner tbh. Next steps for error handling:
- Recognize and error on misinputted space (`q!2mp dragon's breath`)
- Score different types of parsing errors differently to skew error messages in a more helpful way.