### PR TITLE
q!calc Enhancements round 2

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -356,6 +356,7 @@ class AliasRepository extends Array {
     }
 
     isHero(candidate) {
+        if (!candidate || !gHelper.is_str(candidate)) return false;
         return this.allHeroes().includes(candidate.toLowerCase());
     }
 

--- a/commands/calculator.js
+++ b/commands/calculator.js
@@ -154,7 +154,7 @@ function calc(message, args, json) {
 
 // wiz!300 or wiz#300 e.g.
 function isTowerUpgradeCrosspath(t) {
-    if (!/[a-z]+[#!]\d{3}/.test(t)) return false;
+    if (!/[a-z]+[#!]\d{3}/.test(t)) return false;    
 
     let [tower, upgrades] = t.split(/[!#]/)
 
@@ -179,7 +179,7 @@ function costOfTowerUpgradeCrosspath(t, json) {
     if (jsonTowerName === 'engineer') jsonTowerName = 'engineer-monkey'
 
     let mediumCost = null
-    if (t.includes('#')) {
+    if (t.includes('#') || upgrades == '000') {
         // Total cost
         mediumCost = Towers.totalTowerUpgradeCrosspathCost(json, jsonTowerName, upgrades)
     } else if (t.includes("!")) {

--- a/commands/calculator.js
+++ b/commands/calculator.js
@@ -170,6 +170,22 @@ function hard(cost) {
     return Math.round((cost * 1.08) / 5) * 5;
 }
 
+function costOfHero(hero) {
+    switch (Aliases.getCanonicalForm(hero)) {
+        case 'adora': return 1080
+        case 'benjamin': return 1295
+        case 'brickell': return 810
+        case 'churchill': return 2160
+        case 'etienne': return 920
+        case 'ezili': return 650
+        case 'gwen': return 970
+        case 'jones': return 810
+        case 'obyn': return 700
+        case 'pat': return 865
+        case 'quincy': return 585
+    }
+}
+
 // Decipher what type of operand it is, and convert to cost accordingly
 function parseAndValueToken(t, json) {
     if (!isNaN(t)) return Number(t);
@@ -181,6 +197,8 @@ function parseAndValueToken(t, json) {
         return costOfTowerUpgradeCrosspath(t, json);
     } else if (Towers.allTowers().includes(Aliases.getCanonicalForm(t))) {
         return costOfTowerUpgradeCrosspath(`${t}#000`, json);
+    } else if (Aliases.allHeroes().includes(Aliases.getCanonicalForm(t))) {
+        return costOfHero(t);
     } else {
         throw new UnrecognizedTokenError(`Unrecognized token \`${t}\``);
     }
@@ -205,6 +223,10 @@ function helpMessage(message) {
             '`wiz#420`, `super#000`, dart', 
             'TOTAL COST of tower#upgradeSet'
         )
+        .addField(
+            '`adora`, `brick`',
+            'Base cost of hero (no leveling cost calculations included)'
+        )
         .addField('Operators', '`+`, `-`, `*`, `/`, `%` (remainder)')
         .addField(
             'Examples', 
@@ -214,7 +236,6 @@ function helpMessage(message) {
             'Notes',
             'For amgiguous tokens like `wiz!220` and `super!101`, the upgrade is assumed to be the leftmost non-zero digit.'
         )
-        .setFooter('No heroes (just plug in the cost yourself), no discounts on towers (apply the cost reduction yourself if possible)')
         .setColor(colours['black'])
 
     return message.channel.send(helpEmbed);

--- a/commands/calculator.js
+++ b/commands/calculator.js
@@ -58,9 +58,10 @@ function calc(message, args, json) {
     try {
         parsed = parse(expression);
     } catch (e) { // Catches bad character inputs
-        if (c = e.message.match(/Unexpected character at index \d+: (.)/)[1]) {
+        c = e.message.match(/Unexpected character at index \d+: (.)/)[1]
+        if (c) {
             footer = ''
-            if (c == '<') footer = "Did you try to tag another discord user? That's definitely not allowed here."
+            if (c === '<') footer = "Did you try to tag another discord user? That's definitely not allowed here."
             return message.channel.send(
                 new Discord.MessageEmbed()
                     .setTitle(`Unexpected character "${c}"`)

--- a/commands/calculator.js
+++ b/commands/calculator.js
@@ -72,7 +72,7 @@ function calc(message, args, json) {
             return message.channel.send(
                 new Discord.MessageEmbed()
                     .setTitle(`Unexpected error`)
-                    .setDescription(`Report the bug by typing \`q!server\` and following the invite.`)
+                    .setDescription(`Report the bug by typing \`q!server\` and following the invite. Be sure to include the _exact_ q!calc command you typed.`)
                     .setColor(colours['red'])
             );
         }
@@ -198,12 +198,12 @@ function helpMessage(message) {
         )
         .addField('`33.21`, `69.4201`', 'Literally just numbers work')
         .addField(
-            '`wiz!420`, `super!100`', 
-            'INDIVIDUAL COST of tower!upgradeSet (can\'t do just `wiz`)'
+            '`wiz!420`, `super!100`, dart', 
+            'INDIVIDUAL COST of tower!upgradeSet'
         )
         .addField(
-            '`wiz#420`, `super#000`', 
-            'TOTAL COST of tower#upgradeSet (can\'t do just `wiz`)'
+            '`wiz#420`, `super#000`, dart', 
+            'TOTAL COST of tower#upgradeSet'
         )
         .addField('Operators', '`+`, `-`, `*`, `/`, `%` (remainder)')
         .addField(

--- a/commands/calculator.js
+++ b/commands/calculator.js
@@ -55,7 +55,28 @@ function calc(message, args, json) {
 
     // Get the original command arguments string back (other than the command name)
     expression = args.join(' ');
-    parsed = parse(expression);
+    try {
+        parsed = parse(expression);
+    } catch (e) {
+        if (c = e.message.match(/Unexpected character at index \d+: (.)/)[1]) {
+            footer = ''
+            if (c == '<') footer = "Did you try to tag another discord user? That's definitely now allowed here."
+            return message.channel.send(
+                new Discord.MessageEmbed()
+                    .setTitle(`Unexpected character "${c}"`)
+                    .setDescription(`"${c}" is not a valid character in the \`q!calc\` expression. Type \`q!calc\` for help.`)
+                    .setColor(colours['red'])
+                    .setFooter(footer)
+            );
+        } else {
+            return message.channel.send(
+                new Discord.MessageEmbed()
+                    .setTitle(`Unexpected error`)
+                    .setDescription(`Report the bug by typing \`q!server\` and following the invite.`)
+                    .setColor(colours['red'])
+            );
+        }
+    }
 
     var stack = [];
 
@@ -158,6 +179,8 @@ function parseAndValueToken(t, json) {
         return chimps[round].cumulativeCash - chimps[5].cumulativeCash + 650;
     } else if (isTowerUpgradeCrosspath(t)) {
         return costOfTowerUpgradeCrosspath(t, json);
+    } else if (Towers.allTowers().includes(Aliases.getCanonicalForm(t))) {
+        return costOfTowerUpgradeCrosspath(`${t}#000`, json);
     } else {
         throw new UnrecognizedTokenError(`Unrecognized token \`${t}\``);
     }

--- a/commands/calculator.js
+++ b/commands/calculator.js
@@ -150,6 +150,9 @@ function costOfTowerUpgradeCrosspath(t, json) {
     let [tower, upgrades] = t.split(/[!#]/)
 
     jsonTowerName = Aliases.getCanonicalForm(tower).replace(/_/, '-');
+    if (jsonTowerName === 'druid-monkey') jsonTowerName = 'druid'
+    if (jsonTowerName === 'dartling-gunner') throw new UnrecognizedTokenError('Dartling not yet supported')
+    if (jsonTowerName === 'engineer') jsonTowerName = 'engineer-monkey'
 
     let mediumCost = null
     if (t.includes('#')) {
@@ -215,11 +218,11 @@ function helpMessage(message) {
         )
         .addField('`33.21`, `69.4201`', 'Literally just numbers work')
         .addField(
-            '`wiz!420`, `super!100`, `dart`, `wlp`, `gz`, `legend_of_the_night`', 
+            '`wiz!420`, `super!100`, `dart` (same as `dart!000`), `wlp` (same as `wiz!050`)', 
             'INDIVIDUAL COST of tower!upgradeSet'
         )
         .addField(
-            '`wiz#420`, `super#000`, `dart`', 
+            '`wiz#420`, `super#000`', 
             'TOTAL COST of tower#upgradeSet'
         )
         .addField(
@@ -231,10 +234,10 @@ function helpMessage(message) {
             'Examples', 
             '`q!calc r99 - wiz#025 - super#052` (2tc test)\n' + 
                 '`q!calc ninja#502 + ninja#030 * 20 * 0.85` (GMN + single-discounted shinobi army)\n' +
-                '`q!calc vil#002 + (vill#302 + vill#020)*0.85 + vill!400 (camo-mentoring double discount village setup)')
+                '`q!calc vil#002 + (vill#302 + vill#020)*0.85 + vill!400` (camo-mentoring double discount village setup)')
         .addField(
             'Notes',
-            'For amgiguous tokens like `wiz!220` and `super!101`, the upgrade is assumed to be the leftmost non-zero digit.'
+            ' • For ambiguous tokens like `wiz!220` and `super!101`, the upgrade is assumed to be the leftmost non-zero digit.'
         )
         .setColor(colours['black'])
 

--- a/helpers/towers.js
+++ b/helpers/towers.js
@@ -28,14 +28,17 @@ function allTowerPaths() {
 }
 
 function isTowerUpgrade(candidate) {
+    if (!candidate || !gHelper.is_str(candidate)) return false;
     return allTowerUpgrades().includes(candidate.toLowerCase());
 }
 
 function isTower(candidate) {
+    if (!candidate || !gHelper.is_str(candidate)) return false;
     return allTowers().includes(candidate.toLowerCase());
 }
 
 function isTowerPath(candidate) {
+    if (!candidate || !gHelper.is_str(candidate)) return false;
     return allTowerPaths().includes(candidate.toLowerCase());
 }
 
@@ -167,7 +170,7 @@ function crossPathTierFromUpgradeSet(upgradeSet) {
 }
 
 function isValidUpgradeSet(u) {
-    if (!is_str(u) || u.length !== 3) return false;
+    if (!gHelper.is_str(u) || u.length !== 3) return false;
 
     if (isNaN(u)) return false;
 
@@ -203,12 +206,6 @@ function formatTower(tower) {
         throw `Tower ${tower} is not within allotted tower/hero category`;
     }
 }
-function is_str(u) {
-    if (typeof u == 'string') {
-        return true;
-    }
-    return false;
-}
 
 function totalTowerUpgradeCrosspathCost(json, jsonTowerName, upgradeSet) {
     const [path, tier] = Towers.pathTierFromUpgradeSet(upgradeSet);
@@ -236,7 +233,6 @@ function totalTowerUpgradeCrosspathCost(json, jsonTowerName, upgradeSet) {
 }
 
 module.exports = {
-    is_str,
     towerUpgradeToTower,
     allTowerUpgrades,
     allTowers,

--- a/jsons/heroes.json
+++ b/jsons/heroes.json
@@ -491,7 +491,7 @@
 			"cost": 31104
 		}
 	},
-	"ben": {
+	"benjamin": {
 		"1": {
 			"desc": "dummy attack: 20r\n$100 end of round income",
 			"cost": "1200"


### PR DESCRIPTION
**Improvements**:
- Clearer error handling
- Handles base tower names like `heli`
- Handles base hero names like `obyn`
- Handles tower upgrade aliases like `wlp`
(As always, enter `q!calc` to see details)

**Fixes**:
- druid and engi fixed
- dartling comes with an error message for now