### PR TITLE
Display pages for 2tc query overflows; bug fixes

### DIFF
--- a/commands/index-2tc.js
+++ b/commands/index-2tc.js
@@ -254,8 +254,6 @@ async function displayOneOrMultiplePages(userQueryMessage, parsed, combos, colDa
             if (direction < 0) leftIndex++;
         }
     }
-    let maxNumRowsDisplayed = MAX_NUM_ROWS;
-
 
     // Gets the reaction to the pagination message by the command author
     // and respond appropriate action (turning page or deleting message)

--- a/commands/index-2tc.js
+++ b/commands/index-2tc.js
@@ -256,7 +256,7 @@ async function displayOneOrMultiplePages(userQueryMessage, parsed, combos, colDa
     }
 
     // Gets the reaction to the pagination message by the command author
-    // and respond appropriate action (turning page or deleting message)
+    // and respond by turning the page in the correction direction
     function reactLoop(botMessage) {
         // Lays out predefined reactions
         for (var i = 0; i < REACTIONS.length; i++) {

--- a/helpers/towers.js
+++ b/helpers/towers.js
@@ -1,7 +1,10 @@
 const gHelper = require('../helpers/general.js');
 
 function towerUpgradeToTower(towerUpgrade) {
-    return Aliases.getCanonicalForm(towerUpgrade).slice(0, -4);
+    if (!towerUpgrade) return null;
+    canonical = Aliases.getCanonicalForm(towerUpgrade)
+    if (!canonical) return null;
+    return canonical.slice(0, -4);
 }
 
 function allTowerUpgrades() {


### PR DESCRIPTION
A bit of a different technique for doing the react-loop for pages compared to 2mp so compare/contrast if you're interested.