### PR TITLE
`/bloon` feedback from Jazzy

### DIFF
--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -138,8 +138,11 @@ class Enemy {
     }
 
     // Delegates to EnemyClump
-    children() {
-        return this.clump().children()
+    children(format=false) {
+        const children = this.clump().children()
+        if (format) {
+            return children.map(clump => clump.description()).join("\n")  || 'None'
+        } else return children
     }
 
     /**
@@ -164,13 +167,13 @@ class Enemy {
             );
 
             if (numAppearances > 0) {
-                roundAppearances[r.replace(mode, 'R')] = parseInt(numAppearances)
+                roundAppearances[r.replace(mode, 'r')] = parseInt(numAppearances)
             }
         }
 
         if (format) {
             if (Object.keys(roundAppearances).length > 0) {
-                return Object.entries(roundAppearances).map(pair => `**${pair[0]}**: ${pair[1]}`).join(", ")
+                return Object.entries(roundAppearances).map(pair => `${pair[0]}: \`${pair[1]}\``).join(", ")
             } else {
                 return `No natural appearances`
             }
@@ -336,6 +339,14 @@ class Enemy {
 
         if (this.round == 104 || this.round == 114) {
             notes.push("There is a bizarre bug wherein all MOAB class bloons on rounds 104 and 114 have 1 less hp than they should for every layer. Quincybot doesn't take this into account for MOAB health calculation.")
+        }
+
+        if (this.name == BAD && this.round < 100) {
+            notes.push("Warning! Sandbox B.A.D. layer is minimum-capped at r100-strength")
+        }
+
+        if ([BAD, DDT].includes(this.name) && this.round < 90) {
+            notes.push("Warning! Sandbox D.D.T. layer is minimum-capped at r90 strength")
         }
 
         return notes;
@@ -546,6 +557,10 @@ class EnemyClump {
         // console.log(layerRBE, childVerticalRBEs)
         return layerRBE + Math.max(...childVerticalRBEs, 0)
     }
+
+    description() {
+        return `${this.size} ${this.enemy.description()}`
+    }
 }
 
 function formatName(enemyName, formalName=false) {
@@ -591,6 +606,7 @@ function getSpeedRamping(r) {
 
 module.exports = {
     BASE_RED_BLOON_SECONDS_PER_SECOND,
+    ENEMIES_THAT_CAN_BE_SUPER,
 
     ENEMIES, BLOONS, MOABS,
 

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -173,7 +173,7 @@ class Enemy {
 
         if (format) {
             if (Object.keys(roundAppearances).length > 0) {
-                return Object.entries(roundAppearances).map(pair => `${pair[0]}: \`${pair[1]}\``).join(", ")
+                return Object.entries(roundAppearances).map(pair => `**${pair[0]}**: ${pair[1]}`).join(", ")
             } else {
                 return `No natural appearances`
             }

--- a/slash_commands/bloon.js
+++ b/slash_commands/bloon.js
@@ -3,6 +3,7 @@ const {
     Enemy,
     ENEMIES,
     BASE_RED_BLOON_SECONDS_PER_SECOND,
+    ENEMIES_THAT_CAN_BE_SUPER,
     formatName,
     getSpeedRamping,
     getHealthRamping,
@@ -72,27 +73,30 @@ async function execute(interaction) {
     const camo = !!interaction.options.getString('camo')
     const regrow = !!interaction.options.getString('regrow')
 
+    const enemy = new Enemy(enemyName, round, fortified, camo, regrow)
+
     const r80BloonSpeed = BASE_RED_BLOON_SECONDS_PER_SECOND[enemyName]
     const speedRamping = getSpeedRamping(round)
-    const healthRamping = getHealthRamping(round)
+    const healthRamping = enemy.isMOAB() ? getHealthRamping(round) : "Doesn't scale"
     const actualBloonSpeed = r80BloonSpeed * speedRamping
-
-    const enemy = new Enemy(enemyName, round, fortified, camo, regrow)
 
     const displayRound = round <= 80 ? "1-80" : round
 
+    const ignoringSuper = ENEMIES_THAT_CAN_BE_SUPER.includes(enemy.name) ? ' (super and not)' : ''
+
     embed = new Discord.MessageEmbed()
-        .setTitle(`${enemy.description()} (R${displayRound})`)
+        .setTitle(`${enemy.description()} (r${displayRound})`)
         .setThumbnail(await enemy.thumbnail())
         .setColor(cyber)
-        .addField('Speed', `${actualBloonSpeed} RBS/s`, true)
-        .addField('Layer Health', `${enemy.layerRBE(true)} RBE`, true)
-        .addField('Total Health', `${enemy.totalRBE(true)} RBE`, true)
-        .addField('Vertical Health', `${enemy.verticalRBE(true)} RBE`, true)
-        .addField('Speed Factor', `${speedRamping} (xR80)`, true)
-        .addField('Health Factor', `${healthRamping} (xR80)`, true)
-        .addField('Normal Round Appearances', `${enemy.roundAppearances('r', true)}`)
-        .addField('ABR Round Appearances', `${enemy.roundAppearances('ar', true)}`)
+        .addField('Speed', `${actualBloonSpeed} rbs/s`, true)
+        .addField('Layer Health', `${enemy.layerRBE(true)} rbe`, true)
+        .addField('Total Health', `${enemy.totalRBE(true)} rbe`, true)
+        .addField('Vertical Health', `${enemy.verticalRBE(true)} total layers`, true)
+        .addField('Speed Factor', `${speedRamping} (xr80)`, true)
+        .addField('Health Factor', `${healthRamping} (xr80)`, true)
+        .addField('Direct Children', `${enemy.children(true)}`)
+        .addField(`Normal Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('r', true)}`)
+        .addField(`ABR Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('ar', true)}`)
 
     const notes = enemy.notes()
     if (notes.length > 0) {

--- a/slash_commands/bloon.js
+++ b/slash_commands/bloon.js
@@ -84,7 +84,6 @@ async function execute(interaction) {
     const displayRound = round <= 80 ? "1-80" : round
 
     const ignoringSuper = ENEMIES_THAT_CAN_BE_SUPER.includes(enemy.name) ? ' (super and not)' : ''
-    const verticalHealthUnits = enemy.isMOAB() ? 'rbe' : 'total layers'
 
     embed = new Discord.MessageEmbed()
         .setTitle(`${enemy.description()} (r${displayRound})`)
@@ -93,7 +92,7 @@ async function execute(interaction) {
         .addField('Speed', `${actualBloonSpeed} rbs/s`, true)
         .addField('Layer Health', `${enemy.layerRBE(true)} rbe`, true)
         .addField('Total Health', `${enemy.totalRBE(true)} rbe`, true)
-        .addField('Vertical Health', `${enemy.verticalRBE(true)} ${verticalHealthUnits}`, true)
+        .addField('Vertical Health', `${enemy.verticalRBE(true)} rbe`, true)
         .addField('Speed Factor', `${speedRamping} (x r80)`, true)
         .addField('Health Factor', `${healthRampingText}`, true)
         .addField('Direct Children', `${enemy.children(true)}`)

--- a/slash_commands/bloon.js
+++ b/slash_commands/bloon.js
@@ -77,12 +77,14 @@ async function execute(interaction) {
 
     const r80BloonSpeed = BASE_RED_BLOON_SECONDS_PER_SECOND[enemyName]
     const speedRamping = getSpeedRamping(round)
-    const healthRamping = enemy.isMOAB() ? getHealthRamping(round) : "Doesn't scale"
+    const healthRamping = getHealthRamping(round)
+    const healthRampingText = enemy.isMOAB() ? `${healthRamping} (x r80)` : "Doesn't scale"
     const actualBloonSpeed = r80BloonSpeed * speedRamping
 
     const displayRound = round <= 80 ? "1-80" : round
 
     const ignoringSuper = ENEMIES_THAT_CAN_BE_SUPER.includes(enemy.name) ? ' (super and not)' : ''
+    const verticalHealthUnits = enemy.isMOAB() ? 'rbe' : 'total layers'
 
     embed = new Discord.MessageEmbed()
         .setTitle(`${enemy.description()} (r${displayRound})`)
@@ -91,9 +93,9 @@ async function execute(interaction) {
         .addField('Speed', `${actualBloonSpeed} rbs/s`, true)
         .addField('Layer Health', `${enemy.layerRBE(true)} rbe`, true)
         .addField('Total Health', `${enemy.totalRBE(true)} rbe`, true)
-        .addField('Vertical Health', `${enemy.verticalRBE(true)} total layers`, true)
-        .addField('Speed Factor', `${speedRamping} (xr80)`, true)
-        .addField('Health Factor', `${healthRamping} (xr80)`, true)
+        .addField('Vertical Health', `${enemy.verticalRBE(true)} ${verticalHealthUnits}`, true)
+        .addField('Speed Factor', `${speedRamping} (x r80)`, true)
+        .addField('Health Factor', `${healthRampingText}`, true)
         .addField('Direct Children', `${enemy.children(true)}`)
         .addField(`Normal Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('r', true)}`)
         .addField(`ABR Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('ar', true)}`)


### PR DESCRIPTION
* made the Rs in `/bloon` lowercase, as well as RBE and RBS
* show "doesn't scale" for bloon healths
* make the rounds not bolded and then make the the numbers after the rounds code-formatted
* show direct children of enemy
* add some notes for bad/ddt being capped in sandbox