### PR TITLE
`/bloon` cash for enemy

### DIFF
--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -228,6 +228,18 @@ class Enemy {
         return format ? gHelper.numberWithCommas(result) : result
     }
 
+    // Delegates to EnemyClump
+    cash(format=false) {
+        const result = this.clump().cash()
+        return format ? gHelper.numberAsCost(result): result
+    }
+
+    cashEarnedFromLayer() {
+        if (this.isMOAB() || [LEAD, CERAMIC].includes(this.name)) {
+            return 0
+        } else return roundHelper.cashFactorForRound(this.round)
+    }
+
     /**
      * 
      * @param {int} size the amount of the clump, defaults to 1
@@ -556,6 +568,21 @@ class EnemyClump {
         let childVerticalRBEs = this.children().map(child => child.verticalRBE())
         // console.log(layerRBE, childVerticalRBEs)
         return layerRBE + Math.max(...childVerticalRBEs, 0)
+    }
+
+    /**
+     * @returns The total amount of cash earned from this enemy
+     */
+    cash() {
+        let totalCash = this.cashEarnedFromLayer();
+        this.children().forEach(child =>
+            totalCash += child.cash()
+        )
+        return totalCash
+    }
+
+    cashEarnedFromLayer() {
+        return this.enemy.cashEarnedFromLayer() * this.size
     }
 
     description() {

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -234,13 +234,16 @@ class Enemy {
 
     // Delegates to EnemyClump
     cash(format=false) {
-        const result = this.clump().cash()
+        const result = gHelper.round(this.clump().cash(), 2)
         return format ? gHelper.numberAsCost(result): result
     }
 
     cashEarnedFromLayer() {
         if (this.isBloon()) {
-            return roundHelper.cashFactorForRound(this.round)
+            const cashFactor = roundHelper.cashFactorForRound(this.round)
+            if (this.name == CERAMIC && this.isFreeplay()) {
+                return 87 * cashFactor
+            } else return cashFactor
         } else return 0
     }
 

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -234,17 +234,15 @@ class Enemy {
 
     // Delegates to EnemyClump
     cash(format=false) {
-        const result = gHelper.round(this.clump().cash(), 2)
+        const result = gHelper.round(this.clump().cash(), 5)
         return format ? gHelper.numberAsCost(result): result
     }
 
     cashEarnedFromLayer() {
-        if (this.isBloon()) {
-            const cashFactor = roundHelper.cashFactorForRound(this.round)
-            if (this.name == CERAMIC && this.isFreeplay()) {
-                return 87 * cashFactor
-            } else return cashFactor
-        } else return 0
+        const cashFactor = roundHelper.cashFactorForRound(this.round)
+        if (this.name == CERAMIC && this.isFreeplay()) {
+            return 87 * cashFactor
+        } else return cashFactor
     }
 
     /**

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -93,6 +93,13 @@ class Enemy {
             throw `regrow must be true/false; got ${regrow} instead; cannot instantiate Enemy`
         }
 
+        // Sure, DDTs *can* be de-camoed, but let's just do this for simplicity
+        // They can never spawn de-camoed for what it's worth
+        if (name == DDT) {
+            regrow = true
+            camo = true
+        }
+
         this.name = name
         this.fortified = fortified
         this.camo = camo
@@ -107,8 +114,8 @@ class Enemy {
 
     // The bloon's full property/type denotation
     description() {
-        const camo = this.camo ? 'Camo ' : ''
-        const regrow = this.regrow ? 'Regrow ' : ''
+        const camo = this.camo && this.name != DDT ? 'Camo ' : ''
+        const regrow = this.regrow && this.name != DDT ? 'Regrow ' : ''
         const fortified = this.fortified ? 'Fortified ' : ''
         const supr = this.supr() ? 'Super ' : ''
         return `${fortified}${regrow}${camo}${supr}${this.formatName(true)}`
@@ -342,10 +349,6 @@ class Enemy {
         return this.isMOAB() && this.name != DDT && (this.camo || this.regrow)
     }
 
-    hasDDTRedundancy() {
-        return this.name == DDT && (this.camo || this.regrow)
-    }
-
     notes() {
         const notes = []
 
@@ -357,7 +360,7 @@ class Enemy {
             notes.push("Non-DDT MOABs can't have camgrow properties, but their ceramic descendants will. This is only available in challenge editor.")
         }
 
-        if (this.hasDDTRedundancy()) {
+        if (this.name == DDT) {
             notes.push("DDTs have the camgrow property by default")
         }
 

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -184,6 +184,13 @@ class Enemy {
         } else return roundAppearances
     }
 
+    speed(format=false) {
+        const speed = BASE_RED_BLOON_SECONDS_PER_SECOND[this.name] * getSpeedRamping(this.round)
+        if (format) {
+            return gHelper.numberWithCommas(speed)
+        } else return speed
+    }
+
     /**
      * @returns The RBE of the outer layer of the specified enemy on the enemy's specified round
      */
@@ -618,24 +625,28 @@ function isMOAB(enemyName) {
 }
 
 function getHealthRamping(r) {
-    if (r <= 80) return 1;
-    else if (r <= 100) return (r - 30) / 50;
-    else if (r <= 124) return (r - 72) / 20;
-    else if (r <= 150) return (3 * r - 320) / 20;
-    else if (r <= 250) return (7 * r - 920) / 20;
-    else if (r <= 300) return r - 208.5;
-    else if (r <= 400) return (3 * r - 717) / 2;
-    else if (r <= 500) return (5 * r - 1517) / 2;
-    else return 5 * r - 2008.5;
+    let v;
+    if (r <= 80) v = 1;
+    else if (r <= 100) v = (r - 30) / 50;
+    else if (r <= 124) v = (r - 72) / 20;
+    else if (r <= 150) v = (3 * r - 320) / 20;
+    else if (r <= 250) v = (7 * r - 920) / 20;
+    else if (r <= 300) v = r - 208.5;
+    else if (r <= 400) v = (3 * r - 717) / 2;
+    else if (r <= 500) v = (5 * r - 1517) / 2;
+    else v = 5 * r - 2008.5;
+    return gHelper.round(v, 2)
 }
 
 function getSpeedRamping(r) {
-    if (r <= 80) return 1;
-    else if (r <= 100) return 1 + (r - 80) * 0.02;
-    else if (r <= 150) return 1.6 + (r - 101) * 0.02;
-    else if (r <= 200) return 3.0 + (r - 151) * 0.02;
-    else if (r <= 250) return 4.5 + (r - 201) * 0.02;
-    else return 6.0 + (r - 252) * 0.02;
+    let v;
+    if (r <= 80) v = 1;
+    else if (r <= 100) v = 1 + (r - 80) * 0.02;
+    else if (r <= 150) v = 1.6 + (r - 101) * 0.02;
+    else if (r <= 200) v = 3.0 + (r - 151) * 0.02;
+    else if (r <= 250) v = 4.5 + (r - 201) * 0.02;
+    else v = 6.0 + (r - 252) * 0.02;
+    return gHelper.round(v, 2)
 }
 
 module.exports = {

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -576,7 +576,7 @@ class EnemyClump {
     }
 
     /**
-     * @returns The total amount of cash earned from this enemy
+     * @returns The total amount of cash earned from this enemy clump
      */
     cash() {
         let totalCash = this.cashEarnedFromLayer();

--- a/helpers/enemies.js
+++ b/helpers/enemies.js
@@ -125,8 +125,12 @@ class Enemy {
         return `${fortified}${name}${camo}${regrow}`.trim()
     }
 
+    isFreeplay() {
+        return this.round > 80
+    }
+
     supr() {
-        return this.round > 80 && ENEMIES_THAT_CAN_BE_SUPER.includes(this.name)
+        return this.isFreeplay() && ENEMIES_THAT_CAN_BE_SUPER.includes(this.name)
     }
 
     isBloon() {
@@ -235,9 +239,9 @@ class Enemy {
     }
 
     cashEarnedFromLayer() {
-        if (this.isMOAB() || [LEAD, CERAMIC].includes(this.name)) {
-            return 0
-        } else return roundHelper.cashFactorForRound(this.round)
+        if (this.isBloon()) {
+            return roundHelper.cashFactorForRound(this.round)
+        } else return 0
     }
 
     /**
@@ -575,6 +579,8 @@ class EnemyClump {
      */
     cash() {
         let totalCash = this.cashEarnedFromLayer();
+        // Very helpful debug statement:
+        // console.log(this.enemy.description(), `$${totalCash}`, `($${this.enemy.cashEarnedFromLayer()} * ${this.size})`)
         this.children().forEach(child =>
             totalCash += child.cash()
         )

--- a/helpers/general.js
+++ b/helpers/general.js
@@ -194,6 +194,10 @@ function timeSince(date) {
     return Math.floor(seconds) + " seconds";
 }
 
+function round(num, numDigitsAfterDecimal=0) {
+    return Math.round(num * 10**numDigitsAfterDecimal) / 10**numDigitsAfterDecimal
+}
+
 HEAVY_CHECK_MARK = String.fromCharCode(10004) + String.fromCharCode(65039);
 WHITE_HEAVY_CHECK_MARK = String.fromCharCode(9989);
 RED_X = String.fromCharCode(10060);
@@ -217,6 +221,7 @@ module.exports = {
     binaryLambdaSearch,
     addSpaces,
     timeSince,
+    round,
     HEAVY_CHECK_MARK,
     WHITE_HEAVY_CHECK_MARK,
     RED_X,

--- a/helpers/general.js
+++ b/helpers/general.js
@@ -7,7 +7,9 @@ function is_fn(f) {
 }
 
 function numberWithCommas(x) {
-    if (x) return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    let [ones, decimals] = x.toString().split('.')
+    ones = ones.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')
+    return decimals ? `${ones}.${decimals}` : ones
 }
 
 function numberAsCost(x) {

--- a/helpers/rounds.js
+++ b/helpers/rounds.js
@@ -10,6 +10,24 @@ function isValidRound(r) {
     return Number.isInteger(r) && r >= ALL_ROUNDS[0] && r <= ALL_ROUNDS[1]
 }
 
+function cashFactorForRound(r) {
+    if (!isValidRound(r)) {
+        return `${r} is not a valid round`
+    }
+
+    if (r <= 50) {
+        return 1
+    } else if (r <= 60) {
+        return 0.5
+    } else if (r <= 85) {
+        return 0.2
+    } else if (r <= 100) {
+        return 0.1
+    } else {
+        return 0.02
+    }
+}
+
 module.exports = {
     IMPOPPABLE_ROUNDS,
     HARD_ROUNDS,
@@ -20,4 +38,5 @@ module.exports = {
     ALL_ROUNDS,
 
     isValidRound,
+    cashFactorForRound,
 }

--- a/slash_commands/bloon.js
+++ b/slash_commands/bloon.js
@@ -96,6 +96,7 @@ async function execute(interaction) {
         .addField('Speed Factor', `${speedRamping} (x r80)`, true)
         .addField('Health Factor', `${healthRampingText}`, true)
         .addField('Direct Children', `${enemy.children(true)}`)
+        .addField('Cash Earned', `${enemy.cash()}`, true)
         .addField(`Normal Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('r', true)}`)
         .addField(`ABR Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('ar', true)}`)
 

--- a/slash_commands/bloon.js
+++ b/slash_commands/bloon.js
@@ -2,7 +2,6 @@ const { SlashCommandBuilder, SlashCommandStringOption } = require('@discordjs/bu
 const { 
     Enemy,
     ENEMIES,
-    BASE_RED_BLOON_SECONDS_PER_SECOND,
     ENEMIES_THAT_CAN_BE_SUPER,
     formatName,
     getSpeedRamping,
@@ -75,11 +74,9 @@ async function execute(interaction) {
 
     const enemy = new Enemy(enemyName, round, fortified, camo, regrow)
 
-    const r80BloonSpeed = BASE_RED_BLOON_SECONDS_PER_SECOND[enemyName]
     const speedRamping = getSpeedRamping(round)
     const healthRamping = getHealthRamping(round)
     const healthRampingText = enemy.isMOAB() ? `${healthRamping} (x r80)` : "Doesn't scale"
-    const actualBloonSpeed = r80BloonSpeed * speedRamping
 
     const ignoringSuper = ENEMIES_THAT_CAN_BE_SUPER.includes(enemy.name) ? ' (super and not)' : ''
 
@@ -87,7 +84,7 @@ async function execute(interaction) {
         .setTitle(`${enemy.description()} (r${round})`)
         .setThumbnail(await enemy.thumbnail())
         .setColor(cyber)
-        .addField('Speed', `${actualBloonSpeed} rbs/s`, true)
+        .addField('Speed', `${enemy.speed(true)} rbs/s`, true)
         .addField('Layer Health', `${enemy.layerRBE(true)} rbe`, true)
         .addField('Total Health', `${enemy.totalRBE(true)} rbe`, true)
         .addField('Vertical Health', `${enemy.verticalRBE(true)} rbe`, true)

--- a/slash_commands/bloon.js
+++ b/slash_commands/bloon.js
@@ -68,7 +68,7 @@ async function execute(interaction) {
     }
 
     const enemyName = interaction.options.getString('bloon');
-    const round = interaction.options.getInteger('round') || 80; // any round <=80 is default
+    const round = interaction.options.getInteger('round') || 1
     const fortified = !!interaction.options.getString('fortified')
     const camo = !!interaction.options.getString('camo')
     const regrow = !!interaction.options.getString('regrow')
@@ -81,12 +81,10 @@ async function execute(interaction) {
     const healthRampingText = enemy.isMOAB() ? `${healthRamping} (x r80)` : "Doesn't scale"
     const actualBloonSpeed = r80BloonSpeed * speedRamping
 
-    const displayRound = round <= 80 ? "1-80" : round
-
     const ignoringSuper = ENEMIES_THAT_CAN_BE_SUPER.includes(enemy.name) ? ' (super and not)' : ''
 
     embed = new Discord.MessageEmbed()
-        .setTitle(`${enemy.description()} (r${displayRound})`)
+        .setTitle(`${enemy.description()} (r${round})`)
         .setThumbnail(await enemy.thumbnail())
         .setColor(cyber)
         .addField('Speed', `${actualBloonSpeed} rbs/s`, true)
@@ -95,8 +93,9 @@ async function execute(interaction) {
         .addField('Vertical Health', `${enemy.verticalRBE(true)} rbe`, true)
         .addField('Speed Factor', `${speedRamping} (x r80)`, true)
         .addField('Health Factor', `${healthRampingText}`, true)
-        .addField('Direct Children', `${enemy.children(true)}`)
-        .addField('Cash Earned', `${enemy.cash()}`, true)
+        .addField('Direct Children', `${enemy.children(true)}`, true)
+        .addField('Cash Earned', `${enemy.cash(true)}`, true)
+        .addField('Cash Factor', `${roundHelper.cashFactorForRound(round)}`, true)
         .addField(`Normal Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('r', true)}`)
         .addField(`ABR Round Appearances${ignoringSuper}`, `${enemy.roundAppearances('ar', true)}`)
 


### PR DESCRIPTION
Also:
- round all `/bloon` values appropriately
- fix numberWithCommas adding commas after the decimal point, which I don't think is truly standard.
- convert DDTs to camgrow by default