### PR TITLE
Tier 1 and 2 Tower Upgrade Aliases

### DIFF
--- a/alias-repository.js
+++ b/alias-repository.js
@@ -438,7 +438,8 @@ class AliasRepository extends Array {
         return canonical
             .split(separator)
             .map((tk) => gHelper.toTitleCase(tk))
-            .join(' ');
+            .join(' ')
+            .replace(/ \(.*\)/, '');
     }
 
     allRaces() {

--- a/alias-repository.js
+++ b/alias-repository.js
@@ -439,7 +439,7 @@ class AliasRepository extends Array {
             .split(separator)
             .map((tk) => gHelper.toTitleCase(tk))
             .join(' ')
-            .replace(/ \(.*\)/, '');
+            .replace(/ \(.*\)/, ''); // Parentheticals are used to avoid clashing aliases (e.g. double shot) but should be filtered out when displayed
     }
 
     allRaces() {

--- a/alias-repository.js
+++ b/alias-repository.js
@@ -439,7 +439,7 @@ class AliasRepository extends Array {
             .split(separator)
             .map((tk) => gHelper.toTitleCase(tk))
             .join(' ')
-            .replace(/ \(.*\)/, ''); // Parentheticals are used to avoid clashing aliases (e.g. double shot) but should be filtered out when displayed
+            .replace(/ \(.*\)/, ''); // Parentheticals are used to avoid clashing aliases (e.g. double shot) but are filtered out when displayed
     }
 
     allRaces() {

--- a/aliases/towers/magic/alchemist.json
+++ b/aliases/towers/magic/alchemist.json
@@ -12,14 +12,17 @@
         "intoxicant"
     ],
 
+    "200": ["acidic_mixture_drip", "amd"],
     "300": ["berserker_brew", "bbrew"],
     "400": ["stronger_stimulant", "str_stim", "stronger_stim", "stim", "strim", "sstim"],
     "500": ["permanent_brew", "permabrew", "pbrew", "pb"],
 
+    "020": ["perishing_potions", "perishing"],
     "030": ["unstable_concoction", "conc", "unstable", "uc", "coc"],
     "040": ["transforming_tonic", "tonic", "tt4", "trans_tonic"],
     "050": ["total_transformation", "totaltrans", "tt5"],
 
+    "002": ["acid_pool", "acid_pools", "pools", "pool"],
     "003": ["lead_to_gold", "ltg"],
     "004": ["rubber_to_gold", "rtg"],
     "005": ["bloon_master_alchemist","bma","bloon_master"]

--- a/aliases/towers/magic/alchemist.json
+++ b/aliases/towers/magic/alchemist.json
@@ -12,16 +12,19 @@
         "intoxicant"
     ],
 
+    "100": ["larger_potions"],
     "200": ["acidic_mixture_drip", "amd"],
     "300": ["berserker_brew", "bbrew"],
     "400": ["stronger_stimulant", "str_stim", "stronger_stim", "stim", "strim", "sstim"],
     "500": ["permanent_brew", "permabrew", "pbrew", "pb"],
 
+    "010": ["stronger_acid"],
     "020": ["perishing_potions", "perishing"],
     "030": ["unstable_concoction", "conc", "unstable", "uc", "coc"],
     "040": ["transforming_tonic", "tonic", "tt4", "trans_tonic"],
     "050": ["total_transformation", "totaltrans", "tt5"],
 
+    "001": ["faster_throwing_(alchemist)"],
     "002": ["acid_pool", "acid_pools", "pools", "pool"],
     "003": ["lead_to_gold", "ltg"],
     "004": ["rubber_to_gold", "rtg"],

--- a/aliases/towers/magic/druid_monkey.json
+++ b/aliases/towers/magic/druid_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["druid", "drood", "dru"],
 
+    "100": ["hard_thorns"],
     "200": ["heart_of_thunder", "thunder"],
     "300": ["druid_of_the_storm", "dots"],
     "400": ["ball_lightning", "blightning", "ball", "bling", "ball_light"],
     "500": ["superstorm", "super_storm", "storm", "sstorm"],
 
+    "010": ["thorn_swarm", "swarm"],
     "020": ["heart_of_oak", "oak"],
     "030": ["druid_of_the_jungle", "jungle", "dotj"],
     "040": ["jungle's_bounty", "bounty", "jbounty", "jb"],
     "050": ["spirit_of_the_forest", "spirit", "sotf", "soft"],
 
+    "001": ["druidic_reach", "reach"],
     "002": ["heart_of_vengance", "vengance"],
     "003": ["druid_of_wrath", "dow", "wrath"],
     "004": ["poplust", "lust", "pop", "popl"],

--- a/aliases/towers/magic/druid_monkey.json
+++ b/aliases/towers/magic/druid_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["druid", "drood", "dru"],
 
+    "200": ["heart_of_thunder", "thunder"],
     "300": ["druid_of_the_storm", "dots"],
     "400": ["ball_lightning", "blightning", "ball", "bling", "ball_light"],
     "500": ["superstorm", "super_storm", "storm", "sstorm"],
 
+    "020": ["heart_of_oak", "oak"],
     "030": ["druid_of_the_jungle", "jungle", "dotj"],
     "040": ["jungle's_bounty", "bounty", "jbounty", "jb"],
     "050": ["spirit_of_the_forest", "spirit", "sotf", "soft"],
 
+    "002": ["heart_of_vengance", "vengance"],
     "003": ["druid_of_wrath", "dow", "wrath"],
     "004": ["poplust", "lust", "pop", "popl"],
     "005": ["avatar_of_wrath", "aow"]

--- a/aliases/towers/magic/ninja_monkey.json
+++ b/aliases/towers/magic/ninja_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["ninja", "ninja-monkey", "n", "ninj", "shuriken", "nin", "samurai"],
 
+    "100": ["ninja_discipline", "discipline"],
     "200": ["sharp_shurikens", "shurikens"],
     "300": ["double_shot", "d-shot", "dub", "doub", "double"],
     "400": ["bloonjitsu", "bloonjitzu", "jitsu", "jitzu", "bj"],
     "500": ["grandmaster_ninja", "grandmaster", "gmn", "gm"],
 
+    "010": ["distraction"],
     "020": ["counter-espionage", "counter", "espionage"],
     "030": ["shinobi_tactics", "shinobi", "shin", "chinobi", "tactics", "tact", "tacts"],
     "040": ["bloon_sabotage", "sabo", "b_sabo"],
     "050": ["grand_saboteur", "gsabo"],
 
+    "001": ["seeking_shuriken", "seeking"],
     "002": ["caltrops", "trops"],
     "003": ["flash_bomb", "flash", "fbomb"],
     "004": ["sticky_bomb", "sticky", "stick"],

--- a/aliases/towers/magic/ninja_monkey.json
+++ b/aliases/towers/magic/ninja_monkey.json
@@ -1,11 +1,17 @@
 {
     "xyz": ["ninja", "ninja-monkey", "n", "ninj", "shuriken", "nin", "samurai"],
+
+    "200": ["sharp_shurikens", "shurikens"],
     "300": ["double_shot", "d-shot", "dub", "doub", "double"],
     "400": ["bloonjitsu", "bloonjitzu", "jitsu", "jitzu", "bj"],
     "500": ["grandmaster_ninja", "grandmaster", "gmn", "gm"],
+
+    "020": ["counter-espionage", "counter", "espionage"],
     "030": ["shinobi_tactics", "shinobi", "shin", "chinobi", "tactics", "tact", "tacts"],
     "040": ["bloon_sabotage", "sabo", "b_sabo"],
     "050": ["grand_saboteur", "gsabo"],
+
+    "002": ["caltrops", "trops"],
     "003": ["flash_bomb", "flash", "fbomb"],
     "004": ["sticky_bomb", "sticky", "stick"],
     "005": ["master_bomber", "mb", "mbomber"]

--- a/aliases/towers/magic/super_monkey.json
+++ b/aliases/towers/magic/super_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["super", "super-monkey", "supermonkey", "sup"],
 
+    "100": ["laser_blasts", "lasers"],
     "200": ["plasma_blasts", "plasma"],
     "300": ["sun_avatar", "sav", "savatar"],
     "400": ["sun_temple", "temple"],
     "500": ["true_sun_god", "tsg"],
 
+    "010": ["super_range"],
     "020": ["epic_range", "epic"],
     "030": ["robo_monkey", "robo"],
     "040": ["tech_terror", "tt", "technological_terror", "technology", "tech"],
     "050": ["the_anti-bloon", "abloon", "anti", "anti-bloon", "killerrobotofdeath"],
 
+    "001": ["knockback", "kb"],
     "002": ["ultravision", "uvision"],
     "003": ["dark_knight", "dk"],
     "004": ["dark_champion", "dch", "champ", "champion", "dark_champ", "dchamp"],

--- a/aliases/towers/magic/super_monkey.json
+++ b/aliases/towers/magic/super_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["super", "super-monkey", "supermonkey", "sup"],
 
+    "200": ["plasma_blasts", "plasma"],
     "300": ["sun_avatar", "sav", "savatar"],
     "400": ["sun_temple", "temple"],
     "500": ["true_sun_god", "tsg"],
 
+    "020": ["epic_range", "epic"],
     "030": ["robo_monkey", "robo"],
     "040": ["tech_terror", "tt", "technological_terror", "technology", "tech"],
     "050": ["the_anti-bloon", "abloon", "anti", "anti-bloon", "killerrobotofdeath"],
 
+    "002": ["ultravision", "uvision"],
     "003": ["dark_knight", "dk"],
     "004": ["dark_champion", "dch", "champ", "champion", "dark_champ", "dchamp"],
     "005": ["legend_of_the_night", "lotn", "portal"]

--- a/aliases/towers/magic/wizard_monkey.json
+++ b/aliases/towers/magic/wizard_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["wizard", "wizard_monkey", "apprentice", "wiz"],
 
+    "100": ["guided_magic", "guided", "gmagic"],
     "200": ["arcane_blast", "ablast"],
     "300": ["arcane_mastery", "mastery", "amastery"],
     "400": ["arcane_spike", "aspike"],
     "500": ["archmage", "arch", "armchair", "arkmag", "hentai"],
 
+    "010": ["fireball"],
     "020": ["wall_of_fire", "wof"],
     "030": ["dragon's_breath","dbreath","db", "dragon's", "breath"],
     "040": ["summon_phoenix", "sump", "phoenix", "summon"],
     "050": ["wizard_lord_phoenix", "wlp"],
 
+    "001": ["intense_magic", "intense", "imagic"],
     "002": ["monkey_sense", "msense", "sense"],
     "003": ["shimmer", "shim"],
     "004": ["necromancer", "necromancer:_unpopped_army", "necro", "nec", "necr"],

--- a/aliases/towers/magic/wizard_monkey.json
+++ b/aliases/towers/magic/wizard_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["wizard", "wizard_monkey", "apprentice", "wiz"],
 
+    "200": ["arcane_blast", "ablast"],
     "300": ["arcane_mastery", "mastery", "amastery"],
     "400": ["arcane_spike", "aspike"],
     "500": ["archmage", "arch", "armchair", "arkmag", "hentai"],
 
+    "020": ["wall_of_fire", "wof"],
     "030": ["dragon's_breath","dbreath","db", "dragon's", "breath"],
     "040": ["summon_phoenix", "sump", "phoenix", "summon"],
     "050": ["wizard_lord_phoenix", "wlp"],
 
+    "002": ["monkey_sense", "msense", "sense"],
     "003": ["shimmer", "shim"],
     "004": ["necromancer", "necromancer:_unpopped_army", "necro", "nec", "necr"],
     "005": ["prince_of_darkness", "pod", "prince"]

--- a/aliases/towers/military/dartling_gunner.json
+++ b/aliases/towers/military/dartling_gunner.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["dartling", "gunner", "dlg", "dartl"],
 
+    "100": ["focused_firing", "focused"],
     "200": ["laser_shock", "lshock"],
     "300": ["laser_cannon", "lcan"],
     "400": ["plasma_accelerator", "accelerator", "acc", "accel", "accelerate", "paccel", "plasmacc"],
     "500": ["ray_of_doom", "rod", "ray", "ray_of_disappointment"],
 
+    "010": ["advanced_targeting", "atargeting"],
     "020": ["faster_barrel_spin", "faster_spin"],
     "030": ["hydra_rocket_pods", "hydra", "pods", "hrp", "hrps", "hyde", "hyd", "hy"],
     "040": ["rocket_storm", "rstorm"],
     "050": ["m.a.d", "m_a_d", "moab_assured_destroyer"],
 
+    "001": ["faster_swivel"],
     "002": ["powerful_darts"],
     "003": ["buckshot", "buck", "bshot", "buckshit", "fuckshit", "fuckshot"],
     "004": ["bloon_area_denial_system", "bads", "denial", "b.a.d.s"],

--- a/aliases/towers/military/dartling_gunner.json
+++ b/aliases/towers/military/dartling_gunner.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["dartling", "gunner", "dlg", "dartl"],
 
+    "200": ["laser_shock", "lshock"],
     "300": ["laser_cannon", "lcan"],
     "400": ["plasma_accelerator", "accelerator", "acc", "accel", "accelerate", "paccel", "plasmacc"],
     "500": ["ray_of_doom", "rod", "ray", "ray_of_disappointment"],
 
+    "020": ["faster_barrel_spin", "faster_spin"],
     "030": ["hydra_rocket_pods", "hydra", "pods", "hrp", "hrps", "hyde", "hyd", "hy"],
     "040": ["rocket_storm", "rstorm"],
     "050": ["m.a.d", "m_a_d", "moab_assured_destroyer"],
 
+    "002": ["powerful_darts"],
     "003": ["buckshot", "buck", "bshot", "buckshit", "fuckshit", "fuckshot"],
     "004": ["bloon_area_denial_system", "bads", "denial", "b.a.d.s"],
     "005": ["bloon_exclusion_zone", "bez", "excl"]

--- a/aliases/towers/military/heli_pilot.json
+++ b/aliases/towers/military/heli_pilot.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["heli", "heli-pilot", "helicopter", "helipilot", "hel"],
 
+    "200": ["pursuit"],
     "300": ["razor_rotors", "rr", "rotor", "rotors"],
     "400": ["apache_dartship", "adart", "dartship", "dship"],
     "500": ["apache_prime", "aprime", "prime", "prim"],
 
+    "020": ["ifr"],
     "030": ["downdraft", "dd"],
     "040": ["support_chinook", "chinook", "support", "chin"],
     "050": ["special_poperations", "marine", "mar"],
 
+    "002": ["faster_firing"],
     "003": ["moab_shove", "shove"],
     "004": ["comanche_defense", "cdef", "comdef"],
     "005": ["comanche_commander", "commanche_commander","comcom", "commcomm"]

--- a/aliases/towers/military/heli_pilot.json
+++ b/aliases/towers/military/heli_pilot.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["heli", "heli-pilot", "helicopter", "helipilot", "hel"],
 
+    "100": ["quad_darts", "qdarts"],
     "200": ["pursuit"],
     "300": ["razor_rotors", "rr", "rotor", "rotors"],
     "400": ["apache_dartship", "adart", "dartship", "dship"],
     "500": ["apache_prime", "aprime", "prime", "prim"],
 
+    "010": ["bigger_jets", "jets"],
     "020": ["ifr"],
     "030": ["downdraft", "dd"],
     "040": ["support_chinook", "chinook", "support", "chin"],
     "050": ["special_poperations", "marine", "mar"],
 
+    "001": ["faster_darts"],
     "002": ["faster_firing"],
     "003": ["moab_shove", "shove"],
     "004": ["comanche_defense", "cdef", "comdef"],

--- a/aliases/towers/military/monkey_ace.json
+++ b/aliases/towers/military/monkey_ace.json
@@ -1,16 +1,19 @@
 {
 	"xyz": ["ace", "monkey-ace", "pilot", "plane", "airplane"],
 
+    "100": ["rapid_fire"],
     "200": ["lots_more_darts"],
 	"300": ["fighter_plane", "fighter", "fplane"],
 	"400": ["operation:_dart_storm", "ods", "dartstorm"],
 	"500": ["sky_shredder", "shredder", "shred", "sshred", "sshredder", "skyshred", "shredr"],
 
+    "010": ["exploding_pineapple", "pineapple", "pineapples"],
     "020": ["spy_plane"],
 	"030": ["bomber_ace", "bomber"],
 	"040": ["ground_zero", "gz"],
 	"050": ["tsar_bomba", "tb", "tsar", "bomba", "bombagang"],
 
+    "001": ["sharper_darts"],
     "002": ["centered_path"],
 	"003": ["neva-miss_targeting", "neva_miss", "neva", "nm", "miss"],
 	"004": ["spectre", "specter", "spect"],

--- a/aliases/towers/military/monkey_ace.json
+++ b/aliases/towers/military/monkey_ace.json
@@ -1,14 +1,17 @@
 {
 	"xyz": ["ace", "monkey-ace", "pilot", "plane", "airplane"],
 
+    "200": ["lots_more_darts"],
 	"300": ["fighter_plane", "fighter", "fplane"],
 	"400": ["operation:_dart_storm", "ods", "dartstorm"],
 	"500": ["sky_shredder", "shredder", "shred", "sshred", "sshredder", "skyshred", "shredr"],
 
+    "020": ["spy_plane"],
 	"030": ["bomber_ace", "bomber"],
 	"040": ["ground_zero", "gz"],
 	"050": ["tsar_bomba", "tb", "tsar", "bomba", "bombagang"],
-	
+
+    "002": ["centered_path"],
 	"003": ["neva-miss_targeting", "neva_miss", "neva", "nm", "miss"],
 	"004": ["spectre", "specter", "spect"],
 	"005": ["flying_fortress", "ff", "big_plane"]

--- a/aliases/towers/military/monkey_buccaneer.json
+++ b/aliases/towers/military/monkey_buccaneer.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["bucc","monkey-buccaneer","boat","buc","buccaneer"],
 
+    "100": ["faster_shooting_(buccaneer)"],
     "200": ["double_shot_(buccaneer)"],
     "300": ["destroyer","dest"],
     "400": ["aircraft_carrier","aircraft","air"],
     "500": ["carrier_flagship","carrier","flagship","flag","flagshit"],
 
+    "010": ["grape_shot", "grapes", "grapes"],
     "020": ["hot_shot"],
     "030": ["cannon_ship","cannon"],
     "040": ["monkey_pirates","mirates","mpir","hook"],
     "050": ["pirate_lord","plord","pl"],
 
+    "001": ["long_range"],
     "002": ["crow's_nest"],
     "003": ["merchantman","merchant","merch"],
     "004": ["favored_trades","flavored","flavored_trades","fave","trades"],

--- a/aliases/towers/military/monkey_buccaneer.json
+++ b/aliases/towers/military/monkey_buccaneer.json
@@ -1,11 +1,17 @@
 {
     "xyz": ["bucc","monkey-buccaneer","boat","buc","buccaneer"],
+
+    "200": ["double_shot_(buccaneer)"],
     "300": ["destroyer","dest"],
     "400": ["aircraft_carrier","aircraft","air"],
     "500": ["carrier_flagship","carrier","flagship","flag","flagshit"],
+
+    "020": ["hot_shot"],
     "030": ["cannon_ship","cannon"],
     "040": ["monkey_pirates","mirates","mpir","hook"],
     "050": ["pirate_lord","plord","pl"],
+
+    "002": ["crow's_nest"],
     "003": ["merchantman","merchant","merch"],
     "004": ["favored_trades","flavored","flavored_trades","fave","trades"],
     "005": ["trade_empire","empire","emp","trempire"]

--- a/aliases/towers/military/monkey_sub.json
+++ b/aliases/towers/military/monkey_sub.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["sub", "monkey-sub", "submarine", "u-boat"],
 
+    "100": ["longer_range"],
     "200": ["advanced_intel", "intel"],
     "300": ["submerge_and_support", "sas", "submerge"],
     "400": ["bloontonium_reactor", "react", "reactor"],
     "500": ["energizer", "energiser", "engz", "egz", "gizer"],
 
+    "010": ["barbed_darts", "barbs", "barbed"],
     "020": ["heat-tipped_darts"],
     "030": ["ballistic_missile", "balm", "bmiss", "ballistic"],
     "040": ["first_strike_capability", "first_strike", "fs", "fstrike", "fsc"],
     "050": ["pre-emptive_strike", "pre", "preemp", "prestrike", "pstrike", "preemptive"],
 
+    "001": ["twin_guns", "twin", "twins"],
     "002": ["airburst_darts", "airburst"],
     "003": ["triple_guns", "triple", "t_guns", "trip_guns"],
     "004": ["armor_piercing_darts", "armour_piercing_darts", "ap", "apd", "ad_darts", "ap_darts"],

--- a/aliases/towers/military/monkey_sub.json
+++ b/aliases/towers/military/monkey_sub.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["sub", "monkey-sub", "submarine", "u-boat"],
 
+    "200": ["advanced_intel", "intel"],
     "300": ["submerge_and_support", "sas", "submerge"],
     "400": ["bloontonium_reactor", "react", "reactor"],
     "500": ["energizer", "energiser", "engz", "egz", "gizer"],
 
+    "020": ["heat-tipped_darts"],
     "030": ["ballistic_missile", "balm", "bmiss", "ballistic"],
     "040": ["first_strike_capability", "first_strike", "fs", "fstrike", "fsc"],
     "050": ["pre-emptive_strike", "pre", "preemp", "prestrike", "pstrike", "preemptive"],
 
+    "002": ["airburst_darts", "airburst"],
     "003": ["triple_guns", "triple", "t_guns", "trip_guns"],
     "004": ["armor_piercing_darts", "armour_piercing_darts", "ap", "apd", "ad_darts", "ap_darts"],
     "005": ["sub_commander", "subcom", "scom", "scomm"]

--- a/aliases/towers/military/mortar_monkey.json
+++ b/aliases/towers/military/mortar_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["mortar", "mortar-monkey", "mor"],
 
+    "200": ["bloon_buster", "buster"],
     "300": ["shell_shock", "sshock", "shock"],
     "400": ["the_big_one", "bigone", "big", "tbo", "tb0"],
     "500": ["the_biggest_one", "tb1"],
 
+    "020": ["rapid_reload"],
     "030": ["heavy_shells", "heavy"],
     "040": ["artillery_battery", "art", "artillery", "battery", "abat","abattery","artbat"],
     "050": ["pop_and_awe", "paa"],
 
+    "002": ["burny_stuff"],
     "003": ["signal_flare", "signal", "flare"],
     "004": ["shattering_shells", "sshells", "shattering", "shatt", "shat", "shatter"],
     "005": ["blooncineration", "blooncin", "bcin","cin"]

--- a/aliases/towers/military/mortar_monkey.json
+++ b/aliases/towers/military/mortar_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["mortar", "mortar-monkey", "mor"],
 
+    "100": ["bigger_blast"],
     "200": ["bloon_buster", "buster"],
     "300": ["shell_shock", "sshock", "shock"],
     "400": ["the_big_one", "bigone", "big", "tbo", "tb0"],
     "500": ["the_biggest_one", "tb1"],
 
+    "010": ["faster_reload_(mortar_monkey)"],
     "020": ["rapid_reload"],
     "030": ["heavy_shells", "heavy"],
     "040": ["artillery_battery", "art", "artillery", "battery", "abat","abattery","artbat"],
     "050": ["pop_and_awe", "paa"],
 
+    "001": ["increased_accuracy", "accuracy"],
     "002": ["burny_stuff"],
     "003": ["signal_flare", "signal", "flare"],
     "004": ["shattering_shells", "sshells", "shattering", "shatt", "shat", "shatter"],

--- a/aliases/towers/military/sniper_monkey.json
+++ b/aliases/towers/military/sniper_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["sniper", "sniper-monkey", "sn", "sni", "snip", "snooper", "snipermonkey", "gun"],
 
+    "100": ["full_metal_jacket", "fmj"],
     "200": ["larger_calibre", "larger_caliber"],
     "300": ["deadly_precision", "dprecision", "precision"],
     "400": ["maim_moab", "maim", "maimoab", "maimmoab", "mainmoan"],
     "500": ["cripple_moab", "cripple", "cripplemoab"],
 
+    "010": ["night_vision_goggles", "nvg", "goggles", "night_vision"],
     "020": ["shrapnel_shot", "shrapnel"],
     "030": ["bouncing_bullet", "bouncing", "bouncingbullet", "bb","bbullet"],
     "040": ["supply_drop", "supplydrop", "supply", "sd"],
     "050": ["elite_sniper", "es", "esniper", "elitesniper"],
 
+    "001": ["fast_firing"],
     "002": ["even_faster_firing"],
     "003": ["semi_automatic", "semi", "semiauto"],
     "004": ["full_auto_rifle", "fully_automatic", "full_auto", "fully_auto"],

--- a/aliases/towers/military/sniper_monkey.json
+++ b/aliases/towers/military/sniper_monkey.json
@@ -8,7 +8,7 @@
     "030": ["bouncing_bullet", "bouncing", "bouncingbullet", "bb","bbullet"],
     "040": ["supply_drop", "supplydrop", "supply", "sd"],
     "050": ["elite_sniper", "es", "esniper", "elitesniper"],
-    
+
     "003": ["semi_automatic", "semi", "semiauto"],
     "004": ["full_auto_rifle", "fully_automatic", "full_auto", "fully_auto"],
     "005": ["elite_defender", "ed", "edef"]

--- a/aliases/towers/military/sniper_monkey.json
+++ b/aliases/towers/military/sniper_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["sniper", "sniper-monkey", "sn", "sni", "snip", "snooper", "snipermonkey", "gun"],
 
+    "200": ["larger_calibre", "larger_caliber"],
     "300": ["deadly_precision", "dprecision", "precision"],
     "400": ["maim_moab", "maim", "maimoab", "maimmoab", "mainmoan"],
     "500": ["cripple_moab", "cripple", "cripplemoab"],
 
+    "020": ["shrapnel_shot", "shrapnel"],
     "030": ["bouncing_bullet", "bouncing", "bouncingbullet", "bb","bbullet"],
     "040": ["supply_drop", "supplydrop", "supply", "sd"],
     "050": ["elite_sniper", "es", "esniper", "elitesniper"],
 
+    "002": ["even_faster_firing"],
     "003": ["semi_automatic", "semi", "semiauto"],
     "004": ["full_auto_rifle", "fully_automatic", "full_auto", "fully_auto"],
     "005": ["elite_defender", "ed", "edef"]

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -6,7 +6,7 @@
     "400": ["bloon_impact", "impact", "blimpact"],
     "500": ["bloon_crush", "crush", "crunch", "bcrush", "crunchy"],
 
-    "020": ["missile_launcher"],
+    "020": ["missile_launcher", "missiles"],
     "030": ["moab_mauler", "mauler", "maul", "golden_shark", "happy"],
     "040": ["moab_assassin", "assassin", "ass", "black_shark"],
     "050": ["moab_eliminator", "elim", "moab_elim", "green_shark"],

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["bomb", "bmb", "bomb-shooter", "bs", "can", "💣","boom","💥"],
 
+    "200": ["heavy_bombs"],
     "300": ["really_big_bombs", "idk_some_sort_of_alias"],
     "400": ["bloon_impact", "impact", "blimpact"],
     "500": ["bloon_crush", "crush", "crunch", "bcrush", "crunchy"],
 
+    "020": ["missile_launcher"],
     "030": ["moab_mauler", "mauler", "maul", "golden_shark", "happy"],
     "040": ["moab_assassin", "assassin", "ass", "black_shark"],
     "050": ["moab_eliminator", "elim", "moab_elim", "green_shark"],
-    
+
+    "002": ["frag_bombs"],
     "003": ["cluster_bombs", "cluster"],
     "004": ["recursive_cluster", "recursive", "clusters", "recurs", "recurse", "recur"],
     "005": ["bomb_blitz", "blitz", "bblitz"]

--- a/aliases/towers/primary/bomb_shooter.json
+++ b/aliases/towers/primary/bomb_shooter.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["bomb", "bmb", "bomb-shooter", "bs", "can", "💣","boom","💥"],
 
+    "100": ["bigger_bombs"],
     "200": ["heavy_bombs"],
     "300": ["really_big_bombs", "idk_some_sort_of_alias"],
     "400": ["bloon_impact", "impact", "blimpact"],
     "500": ["bloon_crush", "crush", "crunch", "bcrush", "crunchy"],
 
+    "010": ["faster_reload_(bomb_shooter)"],
     "020": ["missile_launcher", "missiles"],
     "030": ["moab_mauler", "mauler", "maul", "golden_shark", "happy"],
     "040": ["moab_assassin", "assassin", "ass", "black_shark"],
     "050": ["moab_eliminator", "elim", "moab_elim", "green_shark"],
 
+    "001": ["extra_range"],
     "002": ["frag_bombs"],
     "003": ["cluster_bombs", "cluster"],
     "004": ["recursive_cluster", "recursive", "clusters", "recurs", "recurse", "recur"],

--- a/aliases/towers/primary/boomerang_monkey.json
+++ b/aliases/towers/primary/boomerang_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["boomer", "boomerang-monkey","boomerang","bm","rang","bomerang","boo","bomer","rangs","bomerrang"],
 
+    "100": ["improved_rangs"],
     "200": ["glaives", "glaive"],
     "300": ["glaive_ricochet", "ricochet", "rich", "rick", "ricoshit"],
     "400": ["m.o.a.r_glaives", "moar", "more"],
     "500": ["glaive_lord", "glord", "gl"],
 
+    "010": ["faster_throwing_(boomerang_monkey)"],
     "020": ["faster_rangs"],
     "030": ["bionic_boomerang", "bionic", "bio"],
     "040": ["turbo_charge", "turbo", "tchar", "tcharge"],
     "050": ["perma_charge", "pcharge", "pc", "pch"],
 
+    "001": ["longer_range_rangs"],
     "002": ["red_hot_rangs"],
     "003": ["kylie_boomerang", "kylie", "kyle", "kyl"],
     "004": ["moab_press", "press", "m_press"],

--- a/aliases/towers/primary/boomerang_monkey.json
+++ b/aliases/towers/primary/boomerang_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["boomer", "boomerang-monkey","boomerang","bm","rang","bomerang","boo","bomer","rangs","bomerrang"],
 
+    "200": ["glaives"],
     "300": ["glaive_ricochet", "ricochet", "rich", "rick", "ricoshit"],
     "400": ["m.o.a.r_glaives", "moar", "more"],
     "500": ["glaive_lord", "glord", "gl", "glaives"],
 
+    "020": ["faster_rangs"],
     "030": ["bionic_boomerang", "bionic", "bio"],
     "040": ["turbo_charge", "turbo", "tchar", "tcharge"],
     "050": ["perma_charge", "pcharge", "pc", "pch"],
-    
+
+    "002": ["red_hot_rangs"],
     "003": ["kylie_boomerang", "kylie", "kyle", "kyl"],
     "004": ["moab_press", "press", "m_press"],
     "005": ["moab_domination", "moab_dom", "m_dom", "domination", "dom", "domm"]

--- a/aliases/towers/primary/boomerang_monkey.json
+++ b/aliases/towers/primary/boomerang_monkey.json
@@ -1,10 +1,10 @@
 {
     "xyz": ["boomer", "boomerang-monkey","boomerang","bm","rang","bomerang","boo","bomer","rangs","bomerrang"],
 
-    "200": ["glaives"],
+    "200": ["glaives", "glaive"],
     "300": ["glaive_ricochet", "ricochet", "rich", "rick", "ricoshit"],
     "400": ["m.o.a.r_glaives", "moar", "more"],
-    "500": ["glaive_lord", "glord", "gl", "glaives"],
+    "500": ["glaive_lord", "glord", "gl"],
 
     "020": ["faster_rangs"],
     "030": ["bionic_boomerang", "bionic", "bio"],

--- a/aliases/towers/primary/dart_monkey.json
+++ b/aliases/towers/primary/dart_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["dart","drt","dart-monkey","dm"],
 
+    "200": ["razor_sharp_shots"],
     "300": ["spike-o-pult","pult","cat","cata","cato","spikepult","spult"],
     "400": ["juggernaut","jugg","jug","naut"],
     "500": ["ultra-juggernaut","ultra_jugg","ultra","ujug","uj","ujugg"],
 
+    "020": ["very_quick_shots"],
     "030": ["triple_shot","trip","tripshot","tdarts","tdart"],
     "040": ["super_monkey_fan_club","smfc","super_funky_man_club","sfmc"],
     "050": ["plasma_monkey_fan_club","pmfc"],
 
+    "002": ["enhanced_eyesight"],
     "003": ["crossbow","xbow"],
     "004": ["sharp_shooter","sharp","sharp_shot","sshot","sshoot","sharp_shitter"],
     "005": ["crossbow_master","xbow_master","xbm"]

--- a/aliases/towers/primary/dart_monkey.json
+++ b/aliases/towers/primary/dart_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["dart","drt","dart-monkey","dm"],
 
+    "100": ["sharp_shots"],
     "200": ["razor_sharp_shots"],
     "300": ["spike-o-pult","pult","cat","cata","cato","spikepult","spult"],
     "400": ["juggernaut","jugg","jug","naut"],
     "500": ["ultra-juggernaut","ultra_jugg","ultra","ujug","uj","ujugg"],
 
+    "010": ["quick_shots"],
     "020": ["very_quick_shots"],
     "030": ["triple_shot","trip","tripshot","tdarts","tdart"],
     "040": ["super_monkey_fan_club","smfc","super_funky_man_club","sfmc"],
     "050": ["plasma_monkey_fan_club","pmfc"],
 
+    "001": ["long_range_darts"],
     "002": ["enhanced_eyesight"],
     "003": ["crossbow","xbow"],
     "004": ["sharp_shooter","sharp","sharp_shot","sshot","sshoot","sharp_shitter"],

--- a/aliases/towers/primary/glue_gunner.json
+++ b/aliases/towers/primary/glue_gunner.json
@@ -1,12 +1,12 @@
 {
     "xyz": ["glue", "glue-gunner", "gg", "glu"],
 
-    "200": ["corrosive_glue"],
+    "200": ["corrosive_glue", "corrosive"],
     "300": ["bloon_dissolver", "diss", "dissolver"],
     "400": ["bloon_liquefier", "liq","liquefier", "liquid"],
     "500": ["the_bloon_solver", "bsol", "solv", "solver", "solve"],
 
-    "020": ["glue_splatter"],
+    "020": ["glue_splatter", "splatter"],
     "030": ["glue_hose", "hose", "ghose", "glose"],
     "040": ["glue_strike", "gstr", "gstrike", "glike"],
     "050": ["glue_storm", "gs", "glorm"],

--- a/aliases/towers/primary/glue_gunner.json
+++ b/aliases/towers/primary/glue_gunner.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["glue", "glue-gunner", "gg", "glu"],
 
+    "100": ["glue_soak", "gl_soak", "g_soak"],
     "200": ["corrosive_glue", "corrosive"],
     "300": ["bloon_dissolver", "diss", "dissolver"],
     "400": ["bloon_liquefier", "liq","liquefier", "liquid"],
     "500": ["the_bloon_solver", "bsol", "solv", "solver", "solve"],
 
+    "010": ["bigger_globs", "globs"],
     "020": ["glue_splatter", "splatter"],
     "030": ["glue_hose", "hose", "ghose", "glose"],
     "040": ["glue_strike", "gstr", "gstrike", "glike"],
     "050": ["glue_storm", "gs", "glorm"],
 
+    "001": ["stickier_glue", "stickier"],
     "002": ["stronger_glue"],
     "003": ["moab_glue", "mglue"],
     "004": ["relentless_glue", "relentless", "relent", "rel", "relglue"],

--- a/aliases/towers/primary/glue_gunner.json
+++ b/aliases/towers/primary/glue_gunner.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["glue", "glue-gunner", "gg", "glu"],
-    
+
+    "200": ["corrosive_glue"],
     "300": ["bloon_dissolver", "diss", "dissolver"],
     "400": ["bloon_liquefier", "liq","liquefier", "liquid"],
     "500": ["the_bloon_solver", "bsol", "solv", "solver", "solve"],
 
+    "020": ["glue_splatter"],
     "030": ["glue_hose", "hose", "ghose", "glose"],
     "040": ["glue_strike", "gstr", "gstrike", "glike"],
     "050": ["glue_storm", "gs", "glorm"],
 
+    "002": ["stronger_glue"],
     "003": ["moab_glue", "mglue"],
     "004": ["relentless_glue", "relentless", "relent", "rel", "relglue"],
     "005": ["super_glue", "sglue"]

--- a/aliases/towers/primary/ice_monkey.json
+++ b/aliases/towers/primary/ice_monkey.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["ice", "ice-monkey", "im"],
 
+    "100": ["permafrost", "p_frost"],
     "200": ["cold_snap"],
     "300": ["ice_shards", "shards", "ishards"],
     "400": ["embrittlement", "brittle", "brit", "brittlement", "britt"],
     "500": ["super_brittle", "sbrit", "sbrittle", "super_brit", "sbritt", "sbrike"],
 
+    "010": ["enhanced_freeze", "enhanced"],
     "020": ["deep_freeze"],
     "030": ["arctic_wind", "wind", "arctic", "awind"],
     "040": ["snowstorm", "snow"],
     "050": ["absolute_zero", "az"],
 
+    "001": ["larger_radius"],
     "002": ["re-freeze"],
     "003": ["cryo_cannon", "cryo"],
     "004": ["icicles", "icy"],

--- a/aliases/towers/primary/ice_monkey.json
+++ b/aliases/towers/primary/ice_monkey.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["ice", "ice-monkey", "im"],
 
+    "200": ["cold_snap"],
     "300": ["ice_shards", "shards", "ishards"],
     "400": ["embrittlement", "brittle", "brit", "brittlement", "britt"],
     "500": ["super_brittle", "sbrit", "sbrittle", "super_brit", "sbritt", "sbrike"],
 
+    "020": ["deep_freeze"],
     "030": ["arctic_wind", "wind", "arctic", "awind"],
     "040": ["snowstorm", "snow"],
     "050": ["absolute_zero", "az"],
-    
+
+    "002": ["re-freeze"],
     "003": ["cryo_cannon", "cryo"],
     "004": ["icicles", "icy"],
     "005": ["icicle_impale", "impale", "iimpale", "impa"]

--- a/aliases/towers/primary/tack_shooter.json
+++ b/aliases/towers/primary/tack_shooter.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["tack", "tack-shooter", "tac", "tak", "ta", "tacc"],
 
+    "200": ["even_faster_shooting"],
     "300": ["hot_shots", "hshots", "hot"],
     "400": ["ring_of_fire", "rof"],
     "500": ["inferno_ring", "inferno", "iring", "ir"],
 
+    "020": ["super_range_tacks"],
     "030": ["blade_shooter", "blades", "blade", "blad"],
     "040": ["blade_maelstrom", "mael", "bmal", "blam"],
     "050": ["super_maelstrom", "smael", "smaelstrom", "smal"],
 
+    "002": ["even_more_tacks"],
     "003": ["tack_sprayer", "spray", "sprayer"],
     "004": ["overdrive", "od", "odrive"],
     "005": ["the_tack_zone", "tz", "ttz", "tzone", "tack_zone"]

--- a/aliases/towers/primary/tack_shooter.json
+++ b/aliases/towers/primary/tack_shooter.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["tack", "tack-shooter", "tac", "tak", "ta", "tacc"],
 
+    "100": ["faster_shooting_(tack_shooter)"],
     "200": ["even_faster_shooting"],
     "300": ["hot_shots", "hshots", "hot"],
     "400": ["ring_of_fire", "rof"],
     "500": ["inferno_ring", "inferno", "iring", "ir"],
 
+    "010": ["long_range_tacks"],
     "020": ["super_range_tacks"],
     "030": ["blade_shooter", "blades", "blade", "blad"],
     "040": ["blade_maelstrom", "mael", "bmal", "blam"],
     "050": ["super_maelstrom", "smael", "smaelstrom", "smal"],
 
+    "001": ["more_tacks"],
     "002": ["even_more_tacks"],
     "003": ["tack_sprayer", "spray", "sprayer"],
     "004": ["overdrive", "od", "odrive"],

--- a/aliases/towers/support/banana_farm.json
+++ b/aliases/towers/support/banana_farm.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["monkey_farm", "farm", "nan", "nana"],
 
+    "200": ["greater_production"],
     "300": ["banana_plantation", "plantation", "plant"],
     "400": ["banana_research_facility", "research", "facility", "brf"],
     "500": ["banana_central", "bcent"],
 
+    "020": ["valuable_bananas", "valuable"],
     "030": ["monkey_bank", "bank"],
     "040": ["imf_loan", "imf", "loan"],
     "050": ["monkey-nomics", "nomics", "economics"],
 
+    "002": ["banana_salvage", "salvage"],
     "003": ["marketplace", "place"],
     "004": ["central_market", "cmarket", "central"],
     "005": ["monkey_wall_street", "wall_street", "wall", "wsb"]

--- a/aliases/towers/support/banana_farm.json
+++ b/aliases/towers/support/banana_farm.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["monkey_farm", "farm", "nan", "nana"],
 
+    "100": ["increased_production"],
     "200": ["greater_production"],
     "300": ["banana_plantation", "plantation", "plant"],
     "400": ["banana_research_facility", "research", "facility", "brf"],
     "500": ["banana_central", "bcent"],
 
+    "010": ["long_life_bananas", "long_life", "llb"],
     "020": ["valuable_bananas", "valuable"],
     "030": ["monkey_bank", "bank"],
     "040": ["imf_loan", "imf", "loan"],
     "050": ["monkey-nomics", "nomics", "economics"],
 
+    "001": ["ez_collect"],
     "002": ["banana_salvage", "salvage"],
     "003": ["marketplace", "place"],
     "004": ["central_market", "cmarket", "central"],

--- a/aliases/towers/support/engineer.json
+++ b/aliases/towers/support/engineer.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["engi","engineer_monkey","engineer","engie","eng","engie"],
 
+    "100": ["sentry_gun", "sgun"],
     "200": ["faster_engineering"],
     "300": ["sprockets", "sproc", "sprock", "sproct"],
     "400": ["sentry_expert", "sexpert"],
     "500": ["sentry_champion", "para", "paragon", "sentry_paragon"],
 
+    "010": ["larger_service_area", "service"],
     "020": ["deconstruction", "decon"],
     "030": ["cleansing_foam", "cleansing", "foam", "cfoam", "clean", "cleans", "cleanse"],
     "040": ["overclock", "oc"],
     "050": ["ultraboost", "uboost"],
 
+    "001": ["oversize_nails", "oversized", "oversize", "o_nails"],
     "002": ["pin"],
     "003": ["double_gun", "dgun"],
     "004": ["bloon_trap", "btrap"],

--- a/aliases/towers/support/engineer.json
+++ b/aliases/towers/support/engineer.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["engi","engineer_monkey","engineer","engie","eng","engie"],
 
+    "200": ["faster_engineering"],
     "300": ["sprockets", "sproc", "sprock", "sproct"],
     "400": ["sentry_expert", "sexpert"],
     "500": ["sentry_champion", "para", "paragon", "sentry_paragon"],
 
+    "020": ["deconstruction", "decon"],
     "030": ["cleansing_foam", "cleansing", "foam", "cfoam", "clean", "cleans", "cleanse"],
     "040": ["overclock", "oc"],
     "050": ["ultraboost", "uboost"],
 
+    "002": ["pin"],
     "003": ["double_gun", "dgun"],
     "004": ["bloon_trap", "btrap"],
     "005": ["xxxl_trap", "xxl", "xl", "xtrap", "xxl_trap", "xxxl", "big_trap"]

--- a/aliases/towers/support/monkey_village.json
+++ b/aliases/towers/support/monkey_village.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["village", "monkey_village", "vil", "vill", "mvil"],
 
+    "200": ["jungle_drums", "drums", "jdrums"],
     "300": ["primary_training", "ptraining", "ptrain", "training"],
     "400": ["primary_mentoring", "pment", "pmentoring", "mentoring"],
     "500": ["primary_expertise", "pe", "primex", "expertise", "pex", "pexpertise"],
 
+    "020": ["radar_scanner", "radar", "scanner"],
     "030": ["monkey_intelligence_bureau", "mib"],
     "040": ["call_to_arms", "cta", "c2a"],
     "050": ["homeland_defense", "homeland_defence", "homeland", "hd"],
 
+    "002": ["monkey_commerce", "commerce"],
     "003": ["monkey_town", "mtown"],
     "004": ["monkey_city", "mcity", "city"],
     "005": ["monkeyopolis", "opolis", "yopolis"]

--- a/aliases/towers/support/monkey_village.json
+++ b/aliases/towers/support/monkey_village.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["village", "monkey_village", "vil", "vill", "mvil"],
 
+    "100": ["bigger_radius", "bradius"],
     "200": ["jungle_drums", "drums", "jdrums"],
     "300": ["primary_training", "ptraining", "ptrain", "training"],
     "400": ["primary_mentoring", "pment", "pmentoring", "mentoring"],
     "500": ["primary_expertise", "pe", "primex", "expertise", "pex", "pexpertise"],
 
+    "010": ["grow_blocker", "gro_blocker", "gblock"],
     "020": ["radar_scanner", "radar", "scanner"],
     "030": ["monkey_intelligence_bureau", "mib"],
     "040": ["call_to_arms", "cta", "c2a"],
     "050": ["homeland_defense", "homeland_defence", "homeland", "hd"],
 
+    "001": ["monkey_business", "business", "m_business"],
     "002": ["monkey_commerce", "commerce"],
     "003": ["monkey_town", "mtown"],
     "004": ["monkey_city", "mcity", "city"],

--- a/aliases/towers/support/spike_factory.json
+++ b/aliases/towers/support/spike_factory.json
@@ -1,16 +1,19 @@
 {
     "xyz": ["spact","factory","spike","spac","spak","spanc","spikes","spi","spk","sf","spacc","spike_shooter","spactory"],
 
+    "100": ["bigger_stacks"],
     "200": ["white_hot_spikes", "white_hot"],
     "300": ["spiked_balls", "sballs", "spalls"],
     "400": ["spiked_mines", "spines"],
     "500": ["super_mines", "swines","smines"],
 
+    "010": ["faster_production"],
     "020": ["even_faster_production"],
     "030": ["moab_shredr", "moab_shredder"],
     "040": ["spike_storm", "sporm"],
     "050": ["carpet_of_spikes", "cos", "carpet"],
 
+    "001": ["long_reach"],
     "002": ["smart_spikes", "smart"],
     "003": ["long_life_spikes", "ll", "lls", "llspike", "llspikes"],
     "004": ["deadly_spikes", "deadly", "dspike", "dspikes"],

--- a/aliases/towers/support/spike_factory.json
+++ b/aliases/towers/support/spike_factory.json
@@ -1,14 +1,17 @@
 {
     "xyz": ["spact","factory","spike","spac","spak","spanc","spikes","spi","spk","sf","spacc","spike_shooter","spactory"],
 
+    "200": ["white_hot_spikes", "white_hot"],
     "300": ["spiked_balls", "sballs", "spalls"],
     "400": ["spiked_mines", "spines"],
     "500": ["super_mines", "swines","smines"],
 
+    "020": ["even_faster_production"],
     "030": ["moab_shredr", "moab_shredder"],
     "040": ["spike_storm", "sporm"],
     "050": ["carpet_of_spikes", "cos", "carpet"],
 
+    "002": ["smart_spikes", "smart"],
     "003": ["long_life_spikes", "ll", "lls", "llspike", "llspikes"],
     "004": ["deadly_spikes", "deadly", "dspike", "dspikes"],
     "005": ["perma-spike", "permaspike", "pspike"]

--- a/slash_commands/alias.js
+++ b/slash_commands/alias.js
@@ -1,0 +1,47 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { cyber } = require('../jsons/colours.json')
+
+builder = new SlashCommandBuilder()
+    .setName('alias')
+    .setDescription('Search and Browse Completed LTC Index Combos')
+    .addStringOption(option => 
+        option.setName('alias').setDescription('The term of which to view other aliases').setRequired(true)
+    )
+
+async function execute(interaction) {
+    const alias = interaction.options.getString('alias').replace(/ /g, '_')
+    const canonicizedAlias = Aliases.canonicizeArg(alias);
+    const aliasSet = Aliases.getAliasSet(canonicizedAlias);
+    
+    let embed;
+    if (aliasSet) {
+        const simplifiedAliases = []
+        const displayedAliases = []
+        aliasSet.forEach(a => {
+            const simplifiedAlias = a.replace(/_|-/g, '')
+            if (!simplifiedAliases.includes(simplifiedAlias)) {
+                simplifiedAliases.push(simplifiedAlias)
+                displayedAliases.push(a)
+            }
+        })
+
+        embed = new Discord.MessageEmbed()
+            .setColor(cyber)
+            .setTitle(`Aliases of \`${alias}\``)
+            .setDescription(displayedAliases.join(', '))
+            .addField('Note',
+                '• `-` and `_` are interchangeable and can be left out entirely when entering slash commands\n' +
+                '• Most slash commands even allow you to replace these separators with spaces, as in `spirit of the forest`'
+            )
+    } else {
+        embed = new Discord.MessageEmbed().setColor(cyber).setTitle(`No Aliases Found for \`${alias}\``)
+    }
+
+    return await interaction.reply({ embeds: [embed] })
+}
+
+module.exports = {
+    data: builder,
+    execute
+};
+    

--- a/slash_commands/alias.js
+++ b/slash_commands/alias.js
@@ -15,6 +15,7 @@ async function execute(interaction) {
     
     let embed;
     if (aliasSet) {
+        // Don't show all separator variations of every alias; just show the variation entered in the file
         const simplifiedAliases = []
         const displayedAliases = []
         aliasSet.forEach(a => {

--- a/slash_commands/alias.js
+++ b/slash_commands/alias.js
@@ -3,7 +3,7 @@ const { cyber } = require('../jsons/colours.json')
 
 builder = new SlashCommandBuilder()
     .setName('alias')
-    .setDescription('Search and Browse Completed LTC Index Combos')
+    .setDescription('Look up aliases of a given term to use in slash commands')
     .addStringOption(option => 
         option.setName('alias').setDescription('The term of which to view other aliases').setRequired(true)
     )

--- a/slash_commands/index-2mp.js
+++ b/slash_commands/index-2mp.js
@@ -120,9 +120,9 @@ function validateInput(interaction) {
 }
 
 function parseAll(interaction) {
-    parsedEntity = parseEntity(interaction);
-    parsedMap = parseMap(interaction);
-    person = parsePerson(interaction);
+    const parsedEntity = parseEntity(interaction);
+    const parsedMap = parseMap(interaction);
+    const person = parsePerson(interaction);
     return [parsedEntity, parsedMap, person];
 }
 
@@ -139,14 +139,26 @@ const UserCommandError = require('../exceptions/user-command-error.js');
 const DeveloperCommandError = require('../exceptions/developer-command-error.js');
 
 function parseEntity(interaction) {
-    entityParser = new OrParser(new TowerParser(), new TowerUpgradeParser(), new HeroParser());
-    entity = interaction.options.getString('entity');
+    const entityParser = new OrParser(new TowerParser(), new TowerUpgradeParser(), new HeroParser());
+    const entity = interaction.options.getString('entity');
     if (entity) {
-        canonicalEntity = Aliases.canonicizeArg(entity);
+        const canonicalEntity = Aliases.canonicizeArg(entity);
         if (canonicalEntity) {
-            return CommandParser.parse([canonicalEntity], entityParser);
+            let parsed = CommandParser.parse([canonicalEntity], entityParser);
+            if (parsed.tower_upgrade) {
+                const [, tier] = Towers.pathTierFromUpgradeSet(
+                    Towers.towerUpgradeToUpgrade(
+                        parsed.tower_upgrade
+                    )
+                )
+                if (tier < 3) {
+                    const tower = Towers.towerUpgradeToTower(parsed.tower_upgrade)
+                    parsed = CommandParser.parse([`${tower}#222`], entityParser)
+                }
+            }
+            return parsed
         } else {
-            parsed = new Parsed();
+            const parsed = new Parsed();
             parsed.addError('Canonical not found');
             return parsed;
         }
@@ -154,14 +166,14 @@ function parseEntity(interaction) {
 }
 
 function parseMap(interaction) {
-    mapParser = new OrParser(new MapParser(), new MapDifficultyParser());
-    map = interaction.options.getString('map');
+    const mapParser = new OrParser(new MapParser(), new MapDifficultyParser());
+    const map = interaction.options.getString('map');
     if (map) {
-        canonicalMap = Aliases.getCanonicalForm(map);
+        const canonicalMap = Aliases.getCanonicalForm(map);
         if (canonicalMap) {
             return CommandParser.parse([canonicalMap], mapParser);
         } else {
-            parsed = new Parsed();
+            const parsed = new Parsed();
             parsed.addError('Canonical not found');
             return parsed;
         }
@@ -169,7 +181,7 @@ function parseMap(interaction) {
 }
 
 function parsePerson(interaction) {
-    person = interaction.options.getString('person')?.toLowerCase();
+    const person = interaction.options.getString('person')?.toLowerCase();
     if (person) {
         return CommandParser.parse([`user#${person}`], new PersonParser());
     } else return new Parsed();

--- a/slash_commands/index-2mp.js
+++ b/slash_commands/index-2mp.js
@@ -110,9 +110,11 @@ async function execute(interaction) {
 function validateInput(interaction) {
     let [parsedEntity, parsedMap, parsedPerson] = parseAll(interaction);
 
-    if (parsedEntity.hasErrors()) return `Entity ${entity} didn't match tower/upgrade/hero, including aliases`;
+    if (parsedEntity.hasErrors()) {
+        return `Entity didn't match tower/upgrade/hero, including aliases`;
+    }
 
-    if (parsedMap.hasErrors()) return `Map/Difficulty ${map} didn't match, including aliases`;
+    if (parsedMap.hasErrors()) return `Map/Difficulty didn't match, including aliases`;
 
     if ((parsedEntity.tower_upgrade || parsedEntity.hero) && parsedMap.map && parsedPerson.person) {
         return "Don't search a person if you're already narrowing down your search to a specific completion";

--- a/slash_commands/index-2mp.js
+++ b/slash_commands/index-2mp.js
@@ -145,6 +145,7 @@ function parseEntity(interaction) {
         const canonicalEntity = Aliases.canonicizeArg(entity);
         if (canonicalEntity) {
             let parsed = CommandParser.parse([canonicalEntity], entityParser);
+            // Alias tier 1 and 2 towers to base tower
             if (parsed.tower_upgrade) {
                 const [, tier] = Towers.pathTierFromUpgradeSet(
                     Towers.towerUpgradeToUpgrade(

--- a/slash_commands/index-2tc.js
+++ b/slash_commands/index-2tc.js
@@ -71,7 +71,19 @@ function parseEntity(interaction, num) {
     if (entity) {
         const canonicalEntity = Aliases.canonicizeArg(entity);
         if (canonicalEntity) {
-            return CommandParser.parse([canonicalEntity], entityParser);
+            let parsed = CommandParser.parse([canonicalEntity], entityParser);
+            if (parsed.tower_upgrade) {
+                const [, tier] = Towers.pathTierFromUpgradeSet(
+                    Towers.towerUpgradeToUpgrade(
+                        parsed.tower_upgrade
+                    )
+                )
+                if (tier < 3) {
+                    const tower = Towers.towerUpgradeToTower(parsed.tower_upgrade)
+                    parsed = CommandParser.parse([`${tower}#222`], entityParser)
+                }
+            }
+            return parsed
         } else {
             const parsed = new Parsed();
             parsed.addError('Canonical not found');
@@ -81,7 +93,7 @@ function parseEntity(interaction, num) {
 }
 
 function parseMap(interaction) {
-    mapParser = new OrParser(new MapParser(), new MapDifficultyParser());
+    const mapParser = new OrParser(new MapParser(), new MapDifficultyParser());
     const map = interaction.options.getString('map');
     if (map) {
         const canonicalMap = Aliases.getCanonicalForm(map);

--- a/slash_commands/index-2tc.js
+++ b/slash_commands/index-2tc.js
@@ -72,6 +72,7 @@ function parseEntity(interaction, num) {
         const canonicalEntity = Aliases.canonicizeArg(entity);
         if (canonicalEntity) {
             let parsed = CommandParser.parse([canonicalEntity], entityParser);
+            // Alias tier 1 and 2 towers to base tower
             if (parsed.tower_upgrade) {
                 const [, tier] = Towers.pathTierFromUpgradeSet(
                     Towers.towerUpgradeToUpgrade(

--- a/slash_commands/tower.js
+++ b/slash_commands/tower.js
@@ -64,8 +64,13 @@ async function embedBloonology(towerName, upgrade) {
     const formattedUpgrade = upgrade.split('').join('-');
     const formattedTowerName = Aliases.toIndexNormalForm(towerName, '-');
 
-    const upgradeName = Towers.towerUpgradeFromTowerAndPathAndTier(towerName, path, tier);
-    const title = `${upgradeName} (${formattedUpgrade} ${formattedTowerName})`;
+    let title;
+    if (tier == 0) {
+        title = `${formattedTowerName} (${formattedUpgrade})`;
+    } else {
+        const upgradeName = Towers.towerUpgradeFromTowerAndPathAndTier(towerName, path, tier);
+        title = `${upgradeName} (${formattedUpgrade} ${formattedTowerName})`;
+    }
 
     let embed = new Discord.MessageEmbed()
         .setTitle(title)

--- a/slash_commands/tower.js
+++ b/slash_commands/tower.js
@@ -65,7 +65,7 @@ async function embedBloonology(towerName, upgrade) {
     const formattedTowerName = Aliases.toIndexNormalForm(towerName, '-');
 
     let title;
-    if (tier <= 2) {
+    if (tier <= 1) {
         title = `${formattedTowerName} (${formattedUpgrade})`;
     } else {
         const upgradeName = Towers.towerUpgradeFromTowerAndPathAndTier(towerName, path, tier);

--- a/slash_commands/tower.js
+++ b/slash_commands/tower.js
@@ -64,13 +64,8 @@ async function embedBloonology(towerName, upgrade) {
     const formattedUpgrade = upgrade.split('').join('-');
     const formattedTowerName = Aliases.toIndexNormalForm(towerName, '-');
 
-    let title;
-    if (tier <= 1) {
-        title = `${formattedTowerName} (${formattedUpgrade})`;
-    } else {
-        const upgradeName = Towers.towerUpgradeFromTowerAndPathAndTier(towerName, path, tier);
-        title = `${upgradeName} (${formattedUpgrade} ${formattedTowerName})`;
-    }
+    const upgradeName = Towers.towerUpgradeFromTowerAndPathAndTier(towerName, path, tier);
+    const title = `${upgradeName} (${formattedUpgrade} ${formattedTowerName})`;
 
     let embed = new Discord.MessageEmbed()
         .setTitle(title)


### PR DESCRIPTION
* `/tower` upgrade titles will display the upgrade name for T1 and T2
* Added `/alias`
* Tier 1 and 2 tower upgrades searched in `/2mp` and `/2tc` will be aliased to the corresponding base tower