### PR TITLE
fix(client): remove unnecessary gateway intents

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,16 +34,7 @@ function globalRequirements() {
     global.AliasRepository = require('./alias-repository.js');
 
     global.Discord = require('discord.js');
-    global.client = new Client({
-        intents: [
-            GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.GuildMessageReactions,
-            GatewayIntentBits.Guilds,
-            GatewayIntentBits.GuildEmojisAndStickers,
-            GatewayIntentBits.DirectMessages,
-            GatewayIntentBits.DirectMessageReactions
-        ]
-    });
+    global.client = new Client({ intents: GatewayIntentBits.Guilds });
 
     global.prefix = require('./1/config.json')['prefix'];
 


### PR DESCRIPTION
Removed all intents except `GUILDS`, as they increase mem usage, and cq can function without them post text based command removal (f89d085b1fcab73b6a2298fd411979806e58770c).

Further testing that requires message content should be done on another bot since cq will no longer be whitelisted to read message content by the end of this month (if I am correct). 