### PR TITLE
Fixed /tierlist

### DIFF
--- a/slash_commands/tierlist.js
+++ b/slash_commands/tierlist.js
@@ -35,27 +35,49 @@ async function execute(interaction) {
 
     switch (version){
         case 9: text = 'https://www.reddit.com/r/btd6/comments/bn7wtu/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 10: text = 'There isn\'t a v10 tier list, go complain to past Randy';
+        break;
         case 11: text = 'https://www.reddit.com/r/btd6/comments/cv5mdi/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 12: text = 'https://www.reddit.com/r/btd6/comments/d9wdk9/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 13: text = 'https://www.reddit.com/r/btd6/comments/dq0xee/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 14: text = 'https://www.reddit.com/r/btd6/comments/eefaum/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 15: text = 'https://www.reddit.com/r/btd6/comments/f1ly0m/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 16: text = 'https://www.reddit.com/r/btd6/comments/ffrkze/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 17: text = 'https://www.reddit.com/r/btd6/comments/g3kiy2/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 18: text = 'https://www.reddit.com/r/btd6/comments/h7iht0/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 19: text = 'https://www.reddit.com/r/btd6/comments/huibn2/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 20: text = 'https://www.reddit.com/r/btd6/comments/irahad/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 21: text = 'https://www.reddit.com/r/btd6/comments/jp0ezq/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 22: text = 'https://www.reddit.com/r/btd6/comments/knnwg9/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 23: text = 'https://www.reddit.com/r/btd6/comments/lyy5v5/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 24: text = 'Exephur sucks and didn\'t make v24 tier list lmao';
+        break;
         case 25: text = 'https://www.reddit.com/r/btd6/comments/nkn8ct/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 26: text = 'Exephur sucks and didn\'t make v26 tier list lmao';
+        break;
         case 27: text = 'https://www.reddit.com/r/btd6/comments/q6f3vs/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 28: text = 'https://www.reddit.com/r/btd6/comments/rc4rkm/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 29: text = 'https://www.reddit.com/r/btd6/comments/sig6c0/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 30: text = 'https://www.reddit.com/r/btd6/comments/ttdrdg/comprehensive_tier_list_for_chimps_by_path/';
+        break;
         case 31: text = 'https://www.reddit.com/r/btd6/comments/uqjt6l/comprehensive_tier_list_for_chimps_by_path/';
     }
     return await interaction.reply({


### PR DESCRIPTION
/tierlist now correctly displays the specified version instead of always returning 31.x tierlist