### PR TITLE
Match full string for round parser

### DIFF
--- a/parser/round-parser.js
+++ b/parser/round-parser.js
@@ -53,7 +53,7 @@ class RoundParser {
     // Parses all ways the command user could enter a round
     transformArgument(arg) {
         if (isNaN(arg)) {
-            var result = arg.match(/(?:round|r)(\d+)/);
+            var result = arg.match(/^(?:round|r)(\d+)$/);
             if (result) return result[1];
             else throw new UserCommandError(`Round must be of form \`15\`, \`R15\` or \`round15\` (Got \`${arg}\` instead)`);
         } else {


### PR DESCRIPTION
> "random garbage followed by "r[number]" actually returns something"

This is an oversight. Fixing!