### PR TITLE
removed the alias for the black bloon

### DIFF
--- a/aliases/enemies/bloons.json
+++ b/aliases/enemies/bloons.json
@@ -4,7 +4,7 @@
     "green": ["gren"],
     "yellow": ["yello"],
     "pink": ["pnk"],
-    "black": ["nig"],
+    "black": [],
     "white": ["wite"],
     "lead": ["metal"],
     "purple": ["purpur","purp"],


### PR DESCRIPTION
while it is a technically a valid alias, I don't think it needs to be said why it shouldn't be included, especially when cyber quincy can type /alias black to reveal it. 