### PR TITLE
Add "SU" abbreviation to sulfur

### DIFF
--- a/aliases/maps/intermediate-maps.json
+++ b/aliases/maps/intermediate-maps.json
@@ -101,6 +101,7 @@
         "wprk"
     ],
     "sulfur_springs": [
+        "su",
         "sulphur_springs",
         "sulfur",
         "sulphur"


### PR DESCRIPTION
added abbreviation to sulfur as this caused quincy to show the full map name